### PR TITLE
Add vanilla SPA frontend for Finanças Pessoais PRO

### DIFF
--- a/financas-pessoais-pro-web/.editorconfig
+++ b/financas-pessoais-pro-web/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/financas-pessoais-pro-web/.gitignore
+++ b/financas-pessoais-pro-web/.gitignore
@@ -1,0 +1,6 @@
+.DS_Store
+node_modules/
+dist/
+*.log
+.idea/
+.vscode/

--- a/financas-pessoais-pro-web/README.md
+++ b/financas-pessoais-pro-web/README.md
@@ -1,0 +1,66 @@
+# Finanças Pessoais PRO Web
+
+SPA em HTML, CSS e JavaScript puro para consumir a API REST Finanças Pessoais PRO.
+
+## Pré-requisitos
+
+- API disponível (por padrão em `http://localhost:8080/api`).
+- Servidor estático simples (`npx serve`, `python -m http.server`, etc.).
+
+## Como rodar
+
+1. Instale um servidor estático global ou use o npx:
+   ```bash
+   npx serve financas-pessoais-pro-web
+   ```
+2. Abra `http://localhost:3000/public` (ou porta informada) no navegador.
+3. Faça login (`#/login`) ou cadastro (`#/signup`).
+
+## Configurando a API
+
+- Valor padrão em `src/config.js` (`window.CONFIG.API_BASE_URL`).
+- Também pode ser ajustado em tempo de execução na tela **Configurações** (`#/settings`). O valor fica salvo em `localStorage` (`fp:api_url`).
+
+## Estrutura de rotas
+
+| Rota          | Descrição                                |
+| ------------- | ---------------------------------------- |
+| `#/login`     | Autenticação                             |
+| `#/signup`    | Cadastro                                 |
+| `#/dashboard` | KPIs, gráficos e indicadores             |
+| `#/accounts`  | CRUD de contas                           |
+| `#/categories`| CRUD de categorias                       |
+| `#/transactions` | Lançamentos com filtros               |
+| `#/transfers` | Transferências entre contas              |
+| `#/recurrings`| Regras recorrentes                       |
+| `#/budgets`   | Metas por categoria                      |
+| `#/reports`   | Relatórios (summary, cashflow, categorias)|
+| `#/settings`  | Perfil, tema e API                       |
+
+## Atalhos de teclado
+
+- `ESC`: fecha modais.
+- `/`: foca na busca global.
+- `g` + `d`: leva ao Dashboard.
+
+## Prints
+
+> Capturas podem ser adicionadas manualmente na pasta `public/` se necessário.
+
+## Desenvolvimento
+
+- Código organizado em módulos ES2022 (`src/`).
+- Roteamento via hash, protegido por token JWT (`localStorage` `fp:token`).
+- Tema dark/light com persistência (`localStorage` `fp:theme`).
+- Service Worker simples (`src/sw.js`) cacheia assets estáticos.
+- Componentes reutilizáveis (`src/components`) e efeitos (`src/effects`).
+
+## Testes rápidos
+
+1. Ajuste `CONFIG.API_BASE_URL` se necessário.
+2. Inicie o servidor estático.
+3. Execute fluxo completo: cadastro → dashboard → CRUDs.
+
+## Licença
+
+Uso interno / demonstração.

--- a/financas-pessoais-pro-web/public/icons/logo.svg
+++ b/financas-pessoais-pro-web/public/icons/logo.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title desc">
+  <title id="title">Finanças Pessoais PRO</title>
+  <desc id="desc">Logotipo circular com seta de crescimento</desc>
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#7c3aed" />
+      <stop offset="100%" stop-color="#22c55e" />
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="8" stdDeviation="8" flood-color="#000" flood-opacity="0.25" />
+    </filter>
+  </defs>
+  <circle cx="64" cy="64" r="58" fill="url(#grad)" filter="url(#shadow)" />
+  <path
+    d="M36 84l18-22 14 14 28-34 6 6-32 40-14-14-12 14z"
+    fill="#fff"
+    stroke="#0b0f14"
+    stroke-width="4"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+</svg>

--- a/financas-pessoais-pro-web/public/index.html
+++ b/financas-pessoais-pro-web/public/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="pt-BR" data-theme="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Finanças Pessoais PRO</title>
+    <meta
+      name="description"
+      content="Painel moderno para controle de finanças pessoais, integrado a API Finanças PRO."
+    />
+    <link rel="manifest" href="./manifest.webmanifest" />
+    <link rel="icon" type="image/svg+xml" href="./icons/logo.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../src/styles/base.css" />
+    <link rel="stylesheet" href="../src/styles/layout.css" />
+    <link rel="stylesheet" href="../src/styles/components.css" />
+    <link rel="stylesheet" href="../src/styles/animations.css" />
+    <link rel="stylesheet" href="../src/styles/themes.css" />
+  </head>
+  <body>
+    <noscript>Ative o JavaScript para utilizar o Finanças Pessoais PRO.</noscript>
+    <div id="app" class="app-shell" aria-live="polite"></div>
+    <div id="modal-root" class="modal-root" aria-live="assertive"></div>
+    <div id="toast-root" class="toast-root" aria-live="polite" aria-atomic="true"></div>
+    <script type="module" src="../src/config.js"></script>
+    <script type="module" src="../src/app.js"></script>
+  </body>
+</html>

--- a/financas-pessoais-pro-web/public/manifest.webmanifest
+++ b/financas-pessoais-pro-web/public/manifest.webmanifest
@@ -1,0 +1,16 @@
+{
+  "name": "Finanças Pessoais PRO",
+  "short_name": "Finanças PRO",
+  "description": "Controle total das suas finanças pessoais com relatórios e dashboards.",
+  "start_url": "./index.html",
+  "display": "standalone",
+  "background_color": "#0b0f14",
+  "theme_color": "#7c3aed",
+  "icons": [
+    {
+      "src": "./icons/logo.svg",
+      "type": "image/svg+xml",
+      "sizes": "any"
+    }
+  ]
+}

--- a/financas-pessoais-pro-web/src/api/endpoints.js
+++ b/financas-pessoais-pro-web/src/api/endpoints.js
@@ -1,0 +1,78 @@
+import http from './http.js';
+import auth from '../state/auth.js';
+import store from '../state/store.js';
+
+const authenticate = async (token) => {
+  auth.setToken(token);
+  const user = await me();
+  auth.setUser(user);
+  return user;
+};
+
+export const login = async ({ email, password }) => {
+  const data = await http.request('/auth/login', {
+    method: 'POST',
+    auth: false,
+    body: { email, password },
+  });
+  return authenticate(data.token);
+};
+
+export const signup = async ({ name, email, password }) => {
+  await http.request('/auth/signup', {
+    method: 'POST',
+    auth: false,
+    body: { name, email, password },
+  });
+  return login({ email, password });
+};
+
+export const me = async () => {
+  const user = await http.request('/me', { method: 'GET' });
+  store.set('auth:user', user);
+  return user;
+};
+
+// Helpers CRUD genéricos
+const buildCrud = (basePath) => ({
+  list: (query = {}) => http.request(`${basePath}${buildQuery(query)}`),
+  create: (payload) => http.request(basePath, { method: 'POST', body: payload }),
+  update: (id, payload) => http.request(`${basePath}/${id}`, { method: 'PATCH', body: payload }),
+  remove: (id) => http.request(`${basePath}/${id}`, { method: 'DELETE' }),
+});
+
+const buildQuery = (params = {}) => {
+  const entries = Object.entries(params).filter(([, value]) => value !== undefined && value !== null && value !== '');
+  if (!entries.length) return '';
+  const search = new URLSearchParams(entries).toString();
+  return `?${search}`;
+};
+
+export const accountsApi = buildCrud('/accounts');
+export const categoriesApi = buildCrud('/categories');
+export const transactionsApi = {
+  ...buildCrud('/transactions'),
+  list: (query = {}) => http.request(`/transactions${buildQuery(query)}`),
+};
+export const transfersApi = buildCrud('/transfers');
+export const recurringsApi = buildCrud('/recurrings');
+export const budgetsApi = buildCrud('/budgets');
+
+export const getSummary = ({ from, to }) => http.request(`/reports/summary${buildQuery({ from, to })}`);
+export const getCashflowDaily = ({ from, to }) => http.request(`/reports/cashflow-daily${buildQuery({ from, to })}`);
+export const getByCategory = ({ from, to }) => http.request(`/reports/by-category${buildQuery({ from, to })}`);
+
+export default {
+  login,
+  signup,
+  me,
+  accountsApi,
+  categoriesApi,
+  transactionsApi,
+  transfersApi,
+  recurringsApi,
+  budgetsApi,
+  getSummary,
+  getCashflowDaily,
+  getByCategory,
+};

--- a/financas-pessoais-pro-web/src/api/http.js
+++ b/financas-pessoais-pro-web/src/api/http.js
@@ -1,0 +1,77 @@
+import CONFIG from '../config.js';
+import auth from '../state/auth.js';
+import router from '../router.js';
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const handleResponse = async (response) => {
+  if (response.ok) {
+    if (response.status === 204) return null;
+    const contentType = response.headers.get('content-type');
+    if (contentType && contentType.includes('application/json')) {
+      return response.json();
+    }
+    return response.text();
+  }
+
+  if (response.status === 401) {
+    auth.logout();
+    router.go('#/login');
+    throw { status: 401, message: 'Sessão expirada. Faça login novamente.' };
+  }
+
+  let data = null;
+  try {
+    data = await response.json();
+  } catch (error) {
+    data = { message: response.statusText };
+  }
+
+  throw {
+    status: response.status,
+    message: data?.message || 'Ocorreu um erro inesperado.',
+    details: data?.details || null,
+  };
+};
+
+const request = async (path, { method = 'GET', headers = {}, body = null, auth: useAuth = true } = {}) => {
+  const maxRetries = 2;
+  let attempt = 0;
+  let lastError;
+
+  while (attempt <= maxRetries) {
+    try {
+      const token = auth.getToken();
+      const requestHeaders = new Headers(headers);
+      if (body && !requestHeaders.has('Content-Type')) {
+        requestHeaders.set('Content-Type', 'application/json');
+      }
+      if (useAuth && token) {
+        requestHeaders.set('Authorization', `Bearer ${token}`);
+      }
+
+      const response = await fetch(`${CONFIG.API_BASE_URL}${path}`, {
+        method,
+        headers: requestHeaders,
+        body: body ? JSON.stringify(body) : null,
+        credentials: 'same-origin',
+      });
+
+      return await handleResponse(response);
+    } catch (error) {
+      lastError = error;
+      if ([429, 503].includes(error.status) && attempt < maxRetries) {
+        await sleep(2 ** attempt * 300);
+        attempt += 1;
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  throw lastError || new Error('Falha ao processar requisição');
+};
+
+export default {
+  request,
+};

--- a/financas-pessoais-pro-web/src/app.js
+++ b/financas-pessoais-pro-web/src/app.js
@@ -1,0 +1,106 @@
+import router from './router.js';
+import auth from './state/auth.js';
+import store from './state/store.js';
+import Toast from './components/Toast.js';
+import Loader from './components/Loader.js';
+import { qs } from './utils/dom.js';
+
+const THEME_KEY = 'fp:theme';
+
+const applyTheme = (theme) => {
+  const html = document.documentElement;
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const resolved = theme === 'system' ? (prefersDark ? 'dark' : 'light') : theme;
+  html.setAttribute('data-theme', resolved);
+  localStorage.setItem(THEME_KEY, theme);
+  store.set('ui:theme', resolved);
+};
+
+const initTheme = () => {
+  const saved = localStorage.getItem(THEME_KEY) || 'dark';
+  applyTheme(saved);
+};
+
+const registerServiceWorker = async () => {
+  if ('serviceWorker' in navigator) {
+    try {
+      const registration = await navigator.serviceWorker.register('/src/sw.js');
+      registration.addEventListener('updatefound', () => {
+        const installing = registration.installing;
+        installing?.addEventListener('statechange', () => {
+          if (installing.state === 'installed' && navigator.serviceWorker.controller) {
+            Toast.show({ message: 'Atualização disponível! Recarregue para ver as novidades.', type: 'info', duration: 6000 });
+          }
+        });
+      });
+    } catch (error) {
+      console.warn('Service Worker não registrado', error);
+    }
+  }
+};
+
+const registerKeyboardShortcuts = () => {
+  document.addEventListener('keydown', (event) => {
+    if (event.defaultPrevented) return;
+    if (event.key === 'Escape') {
+      const modal = qs('.modal.is-open');
+      modal?.dispatchEvent(new CustomEvent('modal:close'));
+    }
+    if (event.key === '/' && !event.target.matches('input, textarea')) {
+      event.preventDefault();
+      const search = qs('[data-global-search] input');
+      search?.focus();
+    }
+    if (event.key === 'd' && event.ctrlKey) {
+      event.preventDefault();
+      applyTheme(document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark');
+    }
+  });
+
+  let sequence = [];
+  document.addEventListener('keydown', (event) => {
+    if (event.defaultPrevented) return;
+    sequence.push(event.key.toLowerCase());
+    if (sequence.slice(-2).join('+') === 'g+d') {
+      router.go('#/dashboard');
+      sequence = [];
+    }
+    if (sequence.length > 2) {
+      sequence.shift();
+    }
+  });
+};
+
+const initAuthState = () => {
+  const token = auth.getToken();
+  store.set('auth:token', token);
+  const user = auth.getUser();
+  if (user) {
+    store.set('auth:user', user);
+  }
+};
+
+const initLoaders = () => {
+  store.subscribe('ui:loading', (isLoading) => {
+    const app = qs('#app');
+    if (!app) return;
+    if (isLoading) {
+      app.classList.add('is-loading');
+    } else {
+      app.classList.remove('is-loading');
+    }
+  });
+};
+
+const boot = () => {
+  initTheme();
+  initAuthState();
+  initLoaders();
+  registerServiceWorker();
+  registerKeyboardShortcuts();
+  Loader.inject();
+  Toast.init();
+  router.init();
+};
+
+document.addEventListener('DOMContentLoaded', boot);

--- a/financas-pessoais-pro-web/src/components/Card.js
+++ b/financas-pessoais-pro-web/src/components/Card.js
@@ -1,0 +1,22 @@
+import { el } from '../utils/dom.js';
+import tilt from '../effects/tilt.js';
+
+const Card = ({ title, subtitle, content, footer, interactive = true }) => {
+  const card = el('article', {
+    class: 'card',
+    children: [
+      title ? el('header', { class: 'card-header', children: [el('h3', { text: title }), subtitle ? el('p', { class: 'card-subtitle', text: subtitle }) : null] }) : null,
+      el('div', { class: 'card-content', children: [content] }),
+      footer ? el('footer', { class: 'card-footer', children: [footer] }) : null,
+    ].filter(Boolean),
+  });
+
+  if (interactive) {
+    tilt(card);
+    card.classList.add('card-interactive');
+  }
+
+  return card;
+};
+
+export default Card;

--- a/financas-pessoais-pro-web/src/components/Chart.js
+++ b/financas-pessoais-pro-web/src/components/Chart.js
@@ -1,0 +1,118 @@
+import { el } from '../utils/dom.js';
+
+const defaultOptions = {
+  type: 'line',
+  data: { labels: [], datasets: [] },
+  options: {
+    tension: 0.4,
+  },
+};
+
+const Chart = (config = {}) => {
+  const cfg = { ...defaultOptions, ...config };
+  const canvas = el('canvas', { class: 'chart-canvas', attrs: { role: 'img' } });
+  const ctx = canvas.getContext('2d');
+
+  const drawLine = () => {
+    const { labels, datasets } = cfg.data;
+    const width = canvas.width;
+    const height = canvas.height;
+    ctx.clearRect(0, 0, width, height);
+
+    const padding = 32;
+    const stepX = (width - padding * 2) / Math.max(1, labels.length - 1);
+
+    datasets.forEach((dataset) => {
+      const values = dataset.data;
+      const max = Math.max(...values);
+      const min = Math.min(...values);
+      const range = max - min || 1;
+
+      ctx.beginPath();
+      ctx.lineWidth = 2;
+      ctx.strokeStyle = dataset.borderColor || '#7c3aed';
+      ctx.shadowColor = dataset.borderColor || '#7c3aed';
+      ctx.shadowBlur = 10;
+
+      values.forEach((value, index) => {
+        const x = padding + index * stepX;
+        const y = height - padding - ((value - min) / range) * (height - padding * 2);
+        if (index === 0) {
+          ctx.moveTo(x, y);
+        } else {
+          ctx.lineTo(x, y);
+        }
+      });
+      ctx.stroke();
+      ctx.shadowBlur = 0;
+    });
+  };
+
+  const drawBar = () => {
+    const { labels, datasets } = cfg.data;
+    const width = canvas.width;
+    const height = canvas.height;
+    ctx.clearRect(0, 0, width, height);
+    const padding = 32;
+    const barWidth = (width - padding * 2) / labels.length;
+    const values = datasets[0]?.data || [];
+    const max = Math.max(...values, 1);
+
+    values.forEach((value, index) => {
+      const x = padding + index * barWidth;
+      const barHeight = ((value / max) * (height - padding * 2));
+      ctx.fillStyle = datasets[0]?.backgroundColor?.[index] || '#22c55e';
+      ctx.fillRect(x, height - padding - barHeight, barWidth * 0.6, barHeight);
+    });
+  };
+
+  const drawPie = () => {
+    const { datasets } = cfg.data;
+    const values = datasets[0]?.data || [];
+    const total = values.reduce((sum, value) => sum + value, 0) || 1;
+    let startAngle = -Math.PI / 2;
+
+    values.forEach((value, index) => {
+      const sliceAngle = (value / total) * Math.PI * 2;
+      ctx.beginPath();
+      ctx.moveTo(canvas.width / 2, canvas.height / 2);
+      ctx.fillStyle = datasets[0]?.backgroundColor?.[index] || '#7c3aed';
+      ctx.arc(
+        canvas.width / 2,
+        canvas.height / 2,
+        Math.min(canvas.width, canvas.height) / 2 - 10,
+        startAngle,
+        startAngle + sliceAngle
+      );
+      ctx.closePath();
+      ctx.fill();
+      startAngle += sliceAngle;
+    });
+  };
+
+  const resize = () => {
+    const rect = canvas.parentElement.getBoundingClientRect();
+    canvas.width = rect.width * window.devicePixelRatio;
+    canvas.height = rect.height * window.devicePixelRatio;
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.scale(window.devicePixelRatio, window.devicePixelRatio);
+    if (cfg.type === 'line') drawLine();
+    if (cfg.type === 'bar') drawBar();
+    if (cfg.type === 'pie') drawPie();
+  };
+
+  const update = (nextConfig) => {
+    Object.assign(cfg, nextConfig);
+    resize();
+  };
+
+  window.addEventListener('resize', resize);
+  setTimeout(resize, 50);
+
+  return {
+    element: el('div', { class: 'chart', children: [canvas] }),
+    update,
+  };
+};
+
+export default Chart;

--- a/financas-pessoais-pro-web/src/components/Chip.js
+++ b/financas-pessoais-pro-web/src/components/Chip.js
@@ -1,0 +1,10 @@
+import { el } from '../utils/dom.js';
+
+const Chip = ({ label, color }) =>
+  el('span', {
+    class: 'chip',
+    text: label,
+    style: color ? `--chip-color: ${color};` : '',
+  });
+
+export default Chip;

--- a/financas-pessoais-pro-web/src/components/DateRange.js
+++ b/financas-pessoais-pro-web/src/components/DateRange.js
@@ -1,0 +1,33 @@
+import { el } from '../utils/dom.js';
+
+const DateRange = ({ from, to, onChange }) => {
+  const startInput = el('input', {
+    type: 'date',
+    value: from,
+    attrs: { 'aria-label': 'Data inicial' },
+  });
+  const endInput = el('input', {
+    type: 'date',
+    value: to,
+    attrs: { 'aria-label': 'Data final' },
+  });
+
+  const container = el('div', {
+    class: 'date-range',
+    children: [startInput, el('span', { class: 'separator', text: 'até' }), endInput],
+  });
+
+  const emitChange = () => onChange?.({ from: startInput.value, to: endInput.value });
+  startInput.addEventListener('change', emitChange);
+  endInput.addEventListener('change', emitChange);
+
+  return {
+    element: container,
+    setRange({ from: newFrom, to: newTo }) {
+      startInput.value = newFrom;
+      endInput.value = newTo;
+    },
+  };
+};
+
+export default DateRange;

--- a/financas-pessoais-pro-web/src/components/Loader.js
+++ b/financas-pessoais-pro-web/src/components/Loader.js
@@ -1,0 +1,31 @@
+import { el } from '../utils/dom.js';
+
+const Loader = {
+  inject() {
+    if (document.getElementById('global-loader')) return;
+    const loader = el('div', {
+      id: 'global-loader',
+      class: 'loader-overlay hidden',
+      attrs: { role: 'status', 'aria-live': 'polite' },
+      children: [
+        el('div', { class: 'loader-spinner', html: '<span class="sr-only">Carregando...</span>' }),
+      ],
+    });
+    document.body.appendChild(loader);
+  },
+  show() {
+    document.getElementById('global-loader')?.classList.remove('hidden');
+  },
+  hide() {
+    document.getElementById('global-loader')?.classList.add('hidden');
+  },
+  skeleton(lines = 3) {
+    const container = el('div', { class: 'skeleton shimmer' });
+    for (let i = 0; i < lines; i += 1) {
+      container.appendChild(el('div', { class: 'skeleton-line' }));
+    }
+    return container;
+  },
+};
+
+export default Loader;

--- a/financas-pessoais-pro-web/src/components/Modal.js
+++ b/financas-pessoais-pro-web/src/components/Modal.js
@@ -1,0 +1,79 @@
+import { el, focusTrap } from '../utils/dom.js';
+
+const Modal = ({ title, content, actions = [] }) => {
+  const overlay = el('div', {
+    class: 'modal-overlay',
+    attrs: { role: 'presentation' },
+  });
+
+  const modal = el('div', {
+    class: 'modal',
+    attrs: {
+      role: 'dialog',
+      'aria-modal': 'true',
+      'aria-labelledby': 'modal-title',
+    },
+    children: [
+      el('header', {
+        class: 'modal-header',
+        children: [
+          el('h2', { id: 'modal-title', text: title }),
+          el('button', {
+            class: 'modal-close',
+            attrs: { 'aria-label': 'Fechar', type: 'button' },
+            html: '&times;',
+          }),
+        ],
+      }),
+      el('div', { class: 'modal-content', children: [content] }),
+      el('footer', {
+        class: 'modal-footer',
+        children: actions.map((action) => {
+          const btn = el('button', {
+            class: `btn ${action.class || ''}`,
+            text: action.label,
+            attrs: { type: action.type || 'button' },
+          });
+          btn.addEventListener('click', () => action.onClick?.({ close }));
+          return btn;
+        }),
+      }),
+    ],
+  });
+
+  overlay.appendChild(modal);
+
+  const trap = focusTrap(modal);
+
+  const close = () => {
+    trap();
+    overlay.classList.remove('is-open');
+    setTimeout(() => overlay.remove(), 200);
+  };
+
+  const onKey = (event) => {
+    if (event.key === 'Escape') {
+      close();
+    }
+  };
+
+  overlay.addEventListener('click', (event) => {
+    if (event.target === overlay) close();
+  });
+
+  modal.querySelector('.modal-close').addEventListener('click', close);
+  overlay.addEventListener('modal:close', close);
+  document.addEventListener('keydown', onKey, { once: true });
+
+  requestAnimationFrame(() => {
+    overlay.classList.add('is-open');
+    modal.classList.add('is-open');
+  });
+
+  return {
+    element: overlay,
+    close,
+  };
+};
+
+export default Modal;

--- a/financas-pessoais-pro-web/src/components/Navbar.js
+++ b/financas-pessoais-pro-web/src/components/Navbar.js
@@ -1,0 +1,118 @@
+import auth from '../state/auth.js';
+import store from '../state/store.js';
+import Toast from './Toast.js';
+import router from '../router.js';
+import { el } from '../utils/dom.js';
+
+const Navbar = () => {
+  const user = auth.getUser();
+
+  const searchInput = el('input', {
+    type: 'search',
+    placeholder: 'Buscar... (/)',
+    attrs: { 'aria-label': 'Buscar', autocomplete: 'off' },
+  });
+
+  const themeToggle = el('button', {
+    class: 'btn-icon',
+    attrs: { 'aria-label': 'Alternar tema' },
+  });
+
+  const profileButton = el('button', {
+    class: 'avatar-button',
+    attrs: { 'aria-haspopup': 'menu', 'aria-expanded': 'false' },
+    children: [
+      el('span', { class: 'avatar', text: user?.name?.[0] ?? '?' }),
+    ],
+  });
+
+  const menu = el('div', {
+    class: 'dropdown-menu',
+    attrs: { role: 'menu' },
+    children: [
+      el('button', { class: 'dropdown-item', text: 'Perfil', attrs: { role: 'menuitem' } }),
+      el('button', { class: 'dropdown-item', text: 'Tema', attrs: { role: 'menuitem' } }),
+      el('button', { class: 'dropdown-item danger', text: 'Sair', attrs: { role: 'menuitem' } }),
+    ],
+  });
+
+  const container = el('header', {
+    class: 'app-navbar glass',
+    children: [
+      el('div', {
+        class: 'navbar-left',
+        children: [
+          el('button', {
+            class: 'btn-icon',
+            attrs: { 'aria-label': 'Alternar menu lateral', 'data-toggle-sidebar': 'true' },
+            html: '<span class="icon-menu"></span>',
+          }),
+          el('div', {
+            class: 'search-field',
+            attrs: { 'data-global-search': 'true' },
+            children: [
+              el('label', { class: 'sr-only', attrs: { for: 'global-search' }, text: 'Buscar' }),
+              Object.assign(searchInput, { id: 'global-search' }),
+            ],
+          }),
+        ],
+      }),
+      el('div', {
+        class: 'navbar-right',
+        children: [
+          themeToggle,
+          el('div', { class: 'profile-menu', children: [profileButton, menu] }),
+        ],
+      }),
+    ],
+  });
+
+  const toggleMenu = () => {
+    const expanded = profileButton.getAttribute('aria-expanded') === 'true';
+    profileButton.setAttribute('aria-expanded', String(!expanded));
+    menu.classList.toggle('open', !expanded);
+  };
+
+  profileButton.addEventListener('click', toggleMenu);
+  profileButton.addEventListener('blur', () => setTimeout(() => menu.classList.remove('open'), 200));
+
+  menu.children[0].addEventListener('click', () => router.go('#/settings'));
+  menu.children[1].addEventListener('click', () => {
+    const current = localStorage.getItem('fp:theme') || 'dark';
+    const next = current === 'dark' ? 'light' : 'dark';
+    localStorage.setItem('fp:theme', next);
+    document.documentElement.setAttribute('data-theme', next);
+    store.set('ui:theme', next);
+    Toast.show({ message: `Tema ${next === 'dark' ? 'escuro' : 'claro'} ativado`, type: 'info' });
+  });
+  menu.children[2].addEventListener('click', () => {
+    auth.logout();
+    Toast.show({ message: 'Sessão encerrada com sucesso.', type: 'info' });
+    router.go('#/login');
+  });
+
+  searchInput.addEventListener('input', (event) => {
+    store.set('ui:search', event.target.value);
+  });
+
+  store.subscribe('ui:theme', (theme) => {
+    themeToggle.innerHTML = theme === 'dark' ? '<span aria-hidden="true">🌙</span>' : '<span aria-hidden="true">☀️</span>';
+  });
+  const initialTheme = document.documentElement.getAttribute('data-theme') || 'dark';
+  themeToggle.innerHTML = initialTheme === 'dark' ? '<span aria-hidden="true">🌙</span>' : '<span aria-hidden="true">☀️</span>';
+
+  themeToggle.addEventListener('click', () => {
+    const current = localStorage.getItem('fp:theme') || 'dark';
+    const next = current === 'dark' ? 'light' : current === 'light' ? 'system' : 'dark';
+    localStorage.setItem('fp:theme', next);
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const resolved = next === 'system' ? (prefersDark ? 'dark' : 'light') : next;
+    document.documentElement.setAttribute('data-theme', resolved);
+    store.set('ui:theme', resolved);
+    Toast.show({ message: `Tema ${resolved} ativado`, type: 'success' });
+  });
+
+  return container;
+};
+
+export default Navbar;

--- a/financas-pessoais-pro-web/src/components/Sidebar.js
+++ b/financas-pessoais-pro-web/src/components/Sidebar.js
@@ -1,0 +1,72 @@
+import router from '../router.js';
+import store from '../state/store.js';
+import { el } from '../utils/dom.js';
+
+const links = [
+  { hash: '#/dashboard', label: 'Dashboard', icon: '📊' },
+  { hash: '#/accounts', label: 'Contas', icon: '🏦' },
+  { hash: '#/categories', label: 'Categorias', icon: '🗂️' },
+  { hash: '#/transactions', label: 'Transações', icon: '💳' },
+  { hash: '#/transfers', label: 'Transferências', icon: '🔁' },
+  { hash: '#/recurrings', label: 'Recorrências', icon: '⏰' },
+  { hash: '#/budgets', label: 'Metas', icon: '🎯' },
+  { hash: '#/reports', label: 'Relatórios', icon: '📈' },
+  { hash: '#/settings', label: 'Configurações', icon: '⚙️' },
+];
+
+const Sidebar = () => {
+  const nav = el('nav', {
+    class: 'app-sidebar glass',
+    attrs: { 'aria-label': 'Navegação principal' },
+  });
+
+  const toggleButton = el('button', {
+    class: 'sidebar-toggle',
+    text: '⇔',
+    attrs: { 'aria-label': 'Alternar tamanho do menu' },
+  });
+
+  const list = el('ul', {
+    class: 'sidebar-links',
+    children: links.map((link) => {
+      const item = el('li', {
+        children: [
+          el('a', {
+            href: link.hash,
+            class: 'sidebar-link',
+            attrs: { 'data-hash': link.hash },
+            html: `<span class="icon">${link.icon}</span><span class="label">${link.label}</span>`,
+          }),
+        ],
+      });
+      item.querySelector('a').addEventListener('click', (event) => {
+        event.preventDefault();
+        router.go(link.hash);
+      });
+      return item;
+    }),
+  });
+
+  nav.append(toggleButton, list);
+
+  toggleButton.addEventListener('click', () => {
+    nav.classList.toggle('collapsed');
+    store.set('ui:sidebar', nav.classList.contains('collapsed'));
+  });
+
+  document.addEventListener('click', (event) => {
+    if (event.target.closest('[data-toggle-sidebar]')) {
+      nav.classList.toggle('collapsed');
+    }
+  });
+
+  store.subscribe('app:route', (hash) => {
+    list.querySelectorAll('a').forEach((a) => {
+      a.classList.toggle('active', a.dataset.hash === hash);
+    });
+  });
+
+  return nav;
+};
+
+export default Sidebar;

--- a/financas-pessoais-pro-web/src/components/Table.js
+++ b/financas-pessoais-pro-web/src/components/Table.js
@@ -1,0 +1,157 @@
+import { el, fragment } from '../utils/dom.js';
+
+const sortData = (data, column, direction) => {
+  const sorted = [...data];
+  sorted.sort((a, b) => {
+    const valueA = a[column];
+    const valueB = b[column];
+    if (valueA === valueB) return 0;
+    if (valueA === undefined) return 1;
+    if (valueB === undefined) return -1;
+    return direction === 'asc' ? (valueA > valueB ? 1 : -1) : valueA > valueB ? -1 : 1;
+  });
+  return sorted;
+};
+
+const paginate = (data, page, perPage) => {
+  const start = (page - 1) * perPage;
+  return data.slice(start, start + perPage);
+};
+
+const Table = ({ columns = [], data = [], emptyMessage = 'Nenhum dado encontrado.', perPage = 10, onRowClick }) => {
+  let sourceData = [...data];
+  let currentPage = 1;
+  let sortColumn = null;
+  let sortDirection = 'asc';
+  let filteredData = [...sourceData];
+
+  const table = el('table', { class: 'table' });
+  const thead = el('thead');
+  const tbody = el('tbody');
+  const pagination = el('div', { class: 'table-pagination' });
+
+  const renderHead = () => {
+    thead.innerHTML = '';
+    const row = el('tr');
+    columns.forEach((column) => {
+      const th = el('th', {
+        text: column.label,
+        attrs: column.sortable ? { 'data-key': column.key, role: 'button', tabindex: '0' } : {},
+      });
+      if (column.sortable) {
+        th.classList.add('sortable');
+        th.addEventListener('click', () => sort(column.key));
+        th.addEventListener('keypress', (event) => {
+          if (event.key === 'Enter') sort(column.key);
+        });
+      }
+      row.appendChild(th);
+    });
+    thead.appendChild(row);
+  };
+
+  const renderBody = () => {
+    tbody.innerHTML = '';
+    const items = paginate(filteredData, currentPage, perPage);
+    if (!items.length) {
+      const emptyRow = el('tr', {
+        children: [el('td', { class: 'empty-state', attrs: { colspan: String(columns.length) }, text: emptyMessage })],
+      });
+      tbody.appendChild(emptyRow);
+      return;
+    }
+
+    tbody.appendChild(
+      fragment(
+        items.map((item) => {
+          const tr = el('tr');
+          if (onRowClick) {
+            tr.classList.add('clickable');
+            tr.addEventListener('click', () => onRowClick(item));
+          }
+          columns.forEach((column) => {
+            const value = column.render ? column.render(item[column.key], item) : item[column.key];
+            const td = el('td');
+            if (value instanceof Node) {
+              td.appendChild(value);
+            } else {
+              td.innerHTML = value ?? '';
+            }
+            tr.appendChild(td);
+          });
+          return tr;
+        })
+      )
+    );
+  };
+
+  const renderPagination = () => {
+    pagination.innerHTML = '';
+    const totalPages = Math.max(1, Math.ceil(filteredData.length / perPage));
+    const info = el('span', { text: `Página ${currentPage} de ${totalPages}` });
+    const prev = el('button', { class: 'btn ghost', text: 'Anterior', attrs: { type: 'button', disabled: currentPage === 1 } });
+    const next = el('button', { class: 'btn ghost', text: 'Próxima', attrs: { type: 'button', disabled: currentPage === totalPages } });
+
+    prev.addEventListener('click', () => {
+      currentPage = Math.max(1, currentPage - 1);
+      renderBody();
+      renderPagination();
+    });
+    next.addEventListener('click', () => {
+      currentPage = Math.min(totalPages, currentPage + 1);
+      renderBody();
+      renderPagination();
+    });
+
+    pagination.append(prev, info, next);
+  };
+
+  const sort = (key) => {
+    if (sortColumn === key) {
+      sortDirection = sortDirection === 'asc' ? 'desc' : 'asc';
+    } else {
+      sortColumn = key;
+      sortDirection = 'asc';
+    }
+    filteredData = sortData(filteredData, sortColumn, sortDirection);
+    currentPage = 1;
+    renderBody();
+    renderPagination();
+  };
+
+  const filter = (term) => {
+    const query = term.trim().toLowerCase();
+    filteredData = !query
+      ? [...sourceData]
+      : sourceData.filter((item) =>
+          columns.some((column) => {
+            if (column.key === 'actions') return false;
+            const value = item[column.key];
+            return String(value ?? '').toLowerCase().includes(query);
+          })
+        );
+    if (sortColumn) {
+      filteredData = sortData(filteredData, sortColumn, sortDirection);
+    }
+    currentPage = 1;
+    renderBody();
+    renderPagination();
+  };
+
+  renderHead();
+  renderBody();
+  renderPagination();
+
+  table.append(thead, tbody);
+
+  return {
+    element: el('div', { class: 'table-wrapper', children: [table, pagination] }),
+    update(newData) {
+      sourceData = [...newData];
+      filter('');
+    },
+    filter,
+  };
+};
+
+export default Table;

--- a/financas-pessoais-pro-web/src/components/Toast.js
+++ b/financas-pessoais-pro-web/src/components/Toast.js
@@ -1,0 +1,42 @@
+import { el, qs } from '../utils/dom.js';
+
+const Toast = {
+  container: null,
+  queue: [],
+  init() {
+    this.container = qs('#toast-root');
+    if (!this.container) {
+      this.container = el('div', { id: 'toast-root', class: 'toast-root' });
+      document.body.appendChild(this.container);
+    }
+  },
+  show({ message, type = 'success', duration = 4000 }) {
+    if (!this.container) this.init();
+    const toast = el('div', {
+      class: `toast toast-${type}`,
+      attrs: { role: 'status' },
+      children: [
+        el('p', { text: message }),
+        el('button', {
+          class: 'toast-close',
+          attrs: { 'aria-label': 'Fechar notificação' },
+          html: '&times;',
+        }),
+      ],
+    });
+
+    const remove = () => {
+      toast.classList.add('leaving');
+      setTimeout(() => toast.remove(), 250);
+    };
+
+    toast.querySelector('.toast-close').addEventListener('click', remove);
+    this.container.appendChild(toast);
+
+    if (duration) {
+      setTimeout(remove, duration);
+    }
+  },
+};
+
+export default Toast;

--- a/financas-pessoais-pro-web/src/config.js
+++ b/financas-pessoais-pro-web/src/config.js
@@ -1,0 +1,9 @@
+// Configuração global do app e carregamento dinâmico de URL da API
+const storedApiUrl = localStorage.getItem('fp:api_url');
+const apiBase = storedApiUrl && storedApiUrl.trim() ? storedApiUrl.trim() : (window.CONFIG?.API_BASE_URL ?? 'http://localhost:8080/api');
+
+window.CONFIG = {
+  API_BASE_URL: apiBase,
+};
+
+export default window.CONFIG;

--- a/financas-pessoais-pro-web/src/effects/confetti.js
+++ b/financas-pessoais-pro-web/src/effects/confetti.js
@@ -1,0 +1,50 @@
+const random = (min, max) => Math.random() * (max - min) + min;
+
+const confetti = () => {
+  const canvas = document.createElement('canvas');
+  canvas.className = 'confetti-canvas';
+  const ctx = canvas.getContext('2d');
+  document.body.appendChild(canvas);
+
+  let width = (canvas.width = window.innerWidth);
+  let height = (canvas.height = window.innerHeight);
+
+  const pieces = Array.from({ length: 150 }, () => ({
+    x: Math.random() * width,
+    y: Math.random() * height - height,
+    size: random(5, 12),
+    speed: random(1, 3),
+    color: `hsl(${random(180, 360)}, 70%, 60%)`,
+    rotation: random(0, Math.PI * 2),
+  }));
+
+  const update = () => {
+    ctx.clearRect(0, 0, width, height);
+    pieces.forEach((piece) => {
+      piece.y += piece.speed;
+      piece.rotation += 0.02;
+      if (piece.y > height) piece.y = -10;
+      ctx.save();
+      ctx.translate(piece.x, piece.y);
+      ctx.rotate(piece.rotation);
+      ctx.fillStyle = piece.color;
+      ctx.fillRect(-piece.size / 2, -piece.size / 2, piece.size, piece.size);
+      ctx.restore();
+    });
+    animationFrame = requestAnimationFrame(update);
+  };
+
+  let animationFrame = requestAnimationFrame(update);
+
+  setTimeout(() => {
+    cancelAnimationFrame(animationFrame);
+    canvas.remove();
+  }, 3000);
+
+  window.addEventListener('resize', () => {
+    width = canvas.width = window.innerWidth;
+    height = canvas.height = window.innerHeight;
+  });
+};
+
+export default confetti;

--- a/financas-pessoais-pro-web/src/effects/parallax.js
+++ b/financas-pessoais-pro-web/src/effects/parallax.js
@@ -1,0 +1,15 @@
+const parallax = (element) => {
+  if (!element) return;
+  const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  if (prefersReduced) return;
+
+  const handle = () => {
+    const offset = window.scrollY * 0.3;
+    element.style.transform = `translate3d(0, ${offset}px, 0)`;
+  };
+
+  window.addEventListener('scroll', handle, { passive: true });
+  handle();
+};
+
+export default parallax;

--- a/financas-pessoais-pro-web/src/effects/tilt.js
+++ b/financas-pessoais-pro-web/src/effects/tilt.js
@@ -1,0 +1,21 @@
+const tilt = (element) => {
+  const handleMouseMove = (event) => {
+    const rect = element.getBoundingClientRect();
+    const x = event.clientX - rect.left;
+    const y = event.clientY - rect.top;
+    const centerX = rect.width / 2;
+    const centerY = rect.height / 2;
+    const rotateX = ((y - centerY) / centerY) * -8;
+    const rotateY = ((x - centerX) / centerX) * 8;
+    element.style.transform = `perspective(600px) rotateX(${rotateX}deg) rotateY(${rotateY}deg)`;
+  };
+
+  const reset = () => {
+    element.style.transform = 'perspective(600px) rotateX(0deg) rotateY(0deg)';
+  };
+
+  element.addEventListener('mousemove', handleMouseMove);
+  element.addEventListener('mouseleave', reset);
+};
+
+export default tilt;

--- a/financas-pessoais-pro-web/src/router.js
+++ b/financas-pessoais-pro-web/src/router.js
@@ -1,0 +1,98 @@
+import auth from './state/auth.js';
+import store from './state/store.js';
+import { qs } from './utils/dom.js';
+
+import LoginView from './views/LoginView.js';
+import SignupView from './views/SignupView.js';
+import DashboardView from './views/DashboardView.js';
+import AccountsView from './views/AccountsView.js';
+import CategoriesView from './views/CategoriesView.js';
+import TransactionsView from './views/TransactionsView.js';
+import TransfersView from './views/TransfersView.js';
+import RecurringsView from './views/RecurringsView.js';
+import BudgetsView from './views/BudgetsView.js';
+import ReportsView from './views/ReportsView.js';
+import SettingsView from './views/SettingsView.js';
+
+const routes = [
+  { path: '#/login', component: LoginView, public: true },
+  { path: '#/signup', component: SignupView, public: true },
+  { path: '#/dashboard', component: DashboardView },
+  { path: '#/accounts', component: AccountsView },
+  { path: '#/categories', component: CategoriesView },
+  { path: '#/transactions', component: TransactionsView },
+  { path: '#/transfers', component: TransfersView },
+  { path: '#/recurrings', component: RecurringsView },
+  { path: '#/budgets', component: BudgetsView },
+  { path: '#/reports', component: ReportsView },
+  { path: '#/settings', component: SettingsView },
+];
+
+let currentViewInstance = null;
+
+const findRoute = (hash) => routes.find((route) => route.path === hash);
+
+const render = async (route) => {
+  const app = qs('#app');
+  if (!app) return;
+  app.setAttribute('data-view', route.path);
+
+  if (currentViewInstance?.destroy) {
+    currentViewInstance.destroy();
+  }
+
+  app.classList.add('view-leave');
+  await new Promise((resolve) => setTimeout(resolve, 120));
+  app.innerHTML = '';
+  app.classList.remove('view-leave');
+  app.classList.add('view-enter');
+
+  currentViewInstance = route.component();
+  const element = await currentViewInstance.render();
+  app.appendChild(element);
+  requestAnimationFrame(() => app.classList.remove('view-enter'));
+};
+
+const guard = (route) => {
+  if (route.public) return true;
+  const token = auth.getToken();
+  if (!token) {
+    window.location.hash = '#/login';
+    return false;
+  }
+  return true;
+};
+
+const handleRouteChange = async () => {
+  const hash = window.location.hash || '#/dashboard';
+  const route = findRoute(hash) || routes[0];
+
+  if (!guard(route)) return;
+
+  store.set('app:route', route.path);
+  await render(route);
+};
+
+const go = (hash) => {
+  if (window.location.hash === hash) {
+    handleRouteChange();
+  } else {
+    window.location.hash = hash;
+  }
+};
+
+window.addEventListener('hashchange', handleRouteChange);
+
+const init = () => {
+  if (!window.location.hash) {
+    window.location.hash = auth.getToken() ? '#/dashboard' : '#/login';
+  } else {
+    handleRouteChange();
+  }
+};
+
+export default {
+  init,
+  go,
+  routes,
+};

--- a/financas-pessoais-pro-web/src/state/auth.js
+++ b/financas-pessoais-pro-web/src/state/auth.js
@@ -1,0 +1,47 @@
+import store from './store.js';
+
+const TOKEN_KEY = 'fp:token';
+const USER_KEY = 'fp:user';
+
+const getToken = () => localStorage.getItem(TOKEN_KEY);
+const setToken = (token) => {
+  if (token) {
+    localStorage.setItem(TOKEN_KEY, token);
+  } else {
+    localStorage.removeItem(TOKEN_KEY);
+  }
+  store.set('auth:token', token);
+};
+
+const getUser = () => {
+  const raw = localStorage.getItem(USER_KEY);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    console.error('Erro ao parsear usuário salvo', error);
+    return null;
+  }
+};
+
+const setUser = (user) => {
+  if (user) {
+    localStorage.setItem(USER_KEY, JSON.stringify(user));
+  } else {
+    localStorage.removeItem(USER_KEY);
+  }
+  store.set('auth:user', user);
+};
+
+const logout = () => {
+  setToken(null);
+  setUser(null);
+};
+
+export default {
+  getToken,
+  setToken,
+  getUser,
+  setUser,
+  logout,
+};

--- a/financas-pessoais-pro-web/src/state/store.js
+++ b/financas-pessoais-pro-web/src/state/store.js
@@ -1,0 +1,33 @@
+// Estado global simples com Pub/Sub
+class Store {
+  constructor() {
+    this.state = new Map();
+    this.listeners = new Map();
+  }
+
+  get(key) {
+    return this.state.get(key);
+  }
+
+  set(key, value) {
+    const previous = this.state.get(key);
+    this.state.set(key, value);
+    if (this.listeners.has(key)) {
+      this.listeners.get(key).forEach((callback) => callback(value, previous));
+    }
+  }
+
+  subscribe(key, callback) {
+    if (!this.listeners.has(key)) {
+      this.listeners.set(key, new Set());
+    }
+    this.listeners.get(key).add(callback);
+    return () => {
+      this.listeners.get(key)?.delete(callback);
+    };
+  }
+}
+
+const store = new Store();
+
+export default store;

--- a/financas-pessoais-pro-web/src/styles/animations.css
+++ b/financas-pessoais-pro-web/src/styles/animations.css
@@ -1,0 +1,34 @@
+@keyframes fade-in {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes slide-up {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes scale-in {
+  from { transform: scale(0.9); opacity: 0; }
+  to { transform: scale(1); opacity: 1; }
+}
+
+@keyframes blob {
+  0% { border-radius: 42% 58% 35% 65% / 40% 45% 55% 60%; }
+  50% { border-radius: 55% 45% 60% 40% / 50% 35% 65% 50%; }
+  100% { border-radius: 42% 58% 35% 65% / 40% 45% 55% 60%; }
+}
+
+@keyframes shimmer {
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+
+.view-enter {
+  animation: fade-in 0.4s ease both;
+}
+
+.view-leave {
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}

--- a/financas-pessoais-pro-web/src/styles/base.css
+++ b/financas-pessoais-pro-web/src/styles/base.css
@@ -1,0 +1,372 @@
+/* Reset básico inspirado em Eric Meyer */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  font-size: 16px;
+  -webkit-text-size-adjust: 100%;
+  scroll-behavior: smooth;
+}
+
+body {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  line-height: 1.5;
+}
+
+img,
+svg {
+  max-width: 100%;
+  display: block;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+  color: inherit;
+  background: transparent;
+  border: none;
+}
+
+button {
+  cursor: pointer;
+}
+
+:root {
+  --bg: #0b0f14;
+  --bg-soft: #0e141b;
+  --card: #0f1720;
+  --text: #e6edf3;
+  --muted: #9fb0c0;
+  --primary: #7c3aed;
+  --primary-600: #6d28d9;
+  --accent: #22c55e;
+  --danger: #ef4444;
+  --warning: #f59e0b;
+  --glass: rgba(255, 255, 255, 0.06);
+  --radius: 16px;
+  --shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+  --transition: 0.25s ease;
+}
+
+[data-theme='light'] {
+  --bg: #f5f7fb;
+  --bg-soft: #eef2ff;
+  --card: #ffffff;
+  --text: #0f172a;
+  --muted: #475569;
+  --primary: #6366f1;
+  --primary-600: #4f46e5;
+  --accent: #16a34a;
+  --danger: #dc2626;
+  --warning: #d97706;
+  --glass: rgba(255, 255, 255, 0.7);
+  --shadow: 0 12px 30px rgba(15, 23, 42, 0.15);
+}
+
+[data-theme='dark'] {
+  color-scheme: dark;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.glass {
+  background: var(--glass);
+  backdrop-filter: blur(12px);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: var(--shadow);
+}
+
+.panel {
+  background: var(--card);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  box-shadow: var(--shadow);
+}
+
+.btn {
+  border-radius: 999px;
+  padding: 0.6rem 1.4rem;
+  font-weight: 600;
+  transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
+  background: var(--glass);
+  border: 1px solid transparent;
+}
+
+.btn.primary {
+  background: linear-gradient(135deg, var(--primary), var(--primary-600));
+  color: #fff;
+  box-shadow: 0 10px 20px rgba(124, 58, 237, 0.35);
+}
+
+.btn.ghost {
+  border-color: rgba(255, 255, 255, 0.15);
+}
+
+.btn.danger {
+  background: var(--danger);
+  color: #fff;
+}
+
+.btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 15px 25px rgba(124, 58, 237, 0.25);
+}
+
+.btn:active {
+  transform: translateY(0);
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 12px;
+  border: 1px solid transparent;
+  padding: 0.75rem 1rem;
+  transition: border var(--transition), box-shadow var(--transition), transform var(--transition);
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 4px rgba(124, 58, 237, 0.25);
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.checkbox {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.checkbox input {
+  width: auto;
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.tag {
+  display: inline-block;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.tag.positive {
+  background: rgba(34, 197, 94, 0.2);
+  color: #4ade80;
+}
+
+.tag.negative {
+  background: rgba(239, 68, 68, 0.25);
+  color: #fca5a5;
+}
+
+.tag.warning {
+  background: rgba(245, 158, 11, 0.2);
+  color: #fbbf24;
+}
+
+.toast-root {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  z-index: 9999;
+}
+
+.toast {
+  padding: 1rem 1.25rem;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  background: var(--card);
+  min-width: 220px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.toast-success { border-left: 4px solid var(--accent); }
+.toast-danger { border-left: 4px solid var(--danger); }
+.toast-info { border-left: 4px solid var(--primary); }
+.toast-warning { border-left: 4px solid var(--warning); }
+
+.toast-close {
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+.toast.leaving {
+  opacity: 0;
+  transform: translateY(-10px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.loader-overlay {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: rgba(11, 15, 20, 0.65);
+  z-index: 9000;
+}
+
+.loader-overlay.hidden {
+  display: none;
+}
+
+.loader-spinner {
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  border: 6px solid rgba(255, 255, 255, 0.1);
+  border-top-color: var(--primary);
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.skeleton {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.skeleton-line {
+  height: 12px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.15), rgba(255, 255, 255, 0.05));
+  animation: shimmer 1.8s infinite;
+}
+
+.auth-view {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 3rem 1.5rem;
+  background: radial-gradient(circle at 0% 0%, rgba(124, 58, 237, 0.18), transparent 60%), radial-gradient(circle at 100% 0%, rgba(34, 197, 94, 0.15), transparent 55%), var(--bg);
+}
+
+.auth-card {
+  max-width: 420px;
+  width: 100%;
+  padding: 2.5rem;
+  border-radius: var(--radius);
+  display: grid;
+  gap: 1.25rem;
+  animation: fade-in 0.4s ease both;
+}
+
+.floating {
+  position: relative;
+  gap: 0;
+}
+
+.floating input {
+  padding-top: 1.5rem;
+}
+
+.floating span {
+  position: absolute;
+  left: 1rem;
+  top: 0.8rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+  pointer-events: none;
+  transition: transform var(--transition), color var(--transition), font-size var(--transition);
+}
+
+.floating input:focus + span,
+.floating input:not(:placeholder-shown) + span {
+  transform: translateY(-0.6rem);
+  font-size: 0.7rem;
+  color: var(--primary);
+}
+
+.form-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.form-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.progress-bar {
+  --progress: 0;
+  width: 100%;
+  height: 12px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  position: relative;
+  overflow: hidden;
+}
+
+.progress-bar::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, var(--accent), var(--primary));
+  transform-origin: left;
+  transform: scaleX(calc(var(--progress, 0) / 100));
+  transition: transform 0.4s ease;
+}
+
+@media (max-width: 768px) {
+  .form-row {
+    flex-direction: column;
+    gap: 1rem;
+    align-items: flex-start;
+  }
+}

--- a/financas-pessoais-pro-web/src/styles/components.css
+++ b/financas-pessoais-pro-web/src/styles/components.css
@@ -1,0 +1,105 @@
+.table tr:nth-child(even) {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.table tr:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.modal-overlay.is-open .modal {
+  animation: scale-in 0.3s ease;
+}
+
+.toast {
+  animation: slide-up 0.3s ease;
+}
+
+.btn:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+.chip::before {
+  content: '';
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-right: 0.4rem;
+  background: currentColor;
+}
+
+.card-content {
+  display: grid;
+  gap: 1rem;
+}
+
+.card-footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.table .tag {
+  font-weight: 600;
+}
+
+.btn:hover {
+  filter: brightness(1.05);
+}
+
+.btn:active {
+  transform: translateY(1px);
+}
+
+.filters button {
+  align-self: end;
+}
+
+.profile-grid dt {
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.profile-grid dd {
+  font-size: 1rem;
+}
+
+.confetti-canvas {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 9999;
+}
+
+.dropdown-menu {
+  min-width: 180px;
+}
+
+.dropdown-menu button {
+  width: 100%;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.chart {
+  position: relative;
+}
+
+.chart::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: var(--radius);
+  background: linear-gradient(145deg, rgba(124, 58, 237, 0.12), transparent 55%);
+  opacity: 0;
+  transition: opacity 0.4s ease;
+}
+
+.chart:hover::after {
+  opacity: 1;
+}

--- a/financas-pessoais-pro-web/src/styles/layout.css
+++ b/financas-pessoais-pro-web/src/styles/layout.css
@@ -1,0 +1,459 @@
+.app-layout {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  min-height: 100vh;
+  background: var(--bg);
+}
+
+.app-sidebar {
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  padding: 2rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.app-sidebar.collapsed {
+  width: 92px;
+}
+
+.sidebar-toggle {
+  align-self: flex-end;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 999px;
+  padding: 0.4rem 0.8rem;
+  color: var(--muted);
+}
+
+.sidebar-links {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.sidebar-link {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.65rem 1rem;
+  border-radius: var(--radius);
+  color: var(--muted);
+  transition: background var(--transition), color var(--transition), transform var(--transition);
+}
+
+.sidebar-link .icon {
+  font-size: 1.25rem;
+}
+
+.sidebar-link.active,
+.sidebar-link:hover {
+  background: rgba(124, 58, 237, 0.2);
+  color: var(--text);
+  transform: translateX(4px);
+}
+
+.app-content {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background: linear-gradient(135deg, rgba(124, 58, 237, 0.12), rgba(34, 197, 94, 0.1)), var(--bg);
+}
+
+.app-navbar {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.5rem;
+  gap: 1rem;
+}
+
+.navbar-left {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.search-field {
+  position: relative;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 999px;
+  padding: 0.4rem 1rem;
+  display: flex;
+  align-items: center;
+}
+
+.search-field input {
+  border: none;
+  background: transparent;
+  padding: 0.25rem 0;
+  width: 200px;
+}
+
+.navbar-right {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.profile-menu {
+  position: relative;
+}
+
+.btn-icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.avatar-button {
+  display: grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--primary), var(--primary-600));
+  color: #fff;
+  box-shadow: 0 10px 25px rgba(124, 58, 237, 0.35);
+}
+
+.dropdown-menu {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  right: 0;
+  background: var(--card);
+  padding: 0.5rem;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  display: none;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.dropdown-menu.open {
+  display: flex;
+}
+
+.dropdown-item {
+  padding: 0.6rem 1rem;
+  border-radius: var(--radius);
+  text-align: left;
+  background: transparent;
+  color: var(--text);
+}
+
+.dropdown-item:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.dropdown-item.danger {
+  color: var(--danger);
+}
+
+.app-main {
+  padding: 2rem;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.view-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
+}
+
+.view-header h1 {
+  font-size: 2rem;
+  font-weight: 700;
+}
+
+.filters {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  padding: 1.5rem;
+  background: var(--card);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+}
+
+.table-wrapper {
+  background: var(--card);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  padding: 1rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.table th {
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+  color: var(--muted);
+  text-transform: uppercase;
+}
+
+.table tr:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.table-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.table-pagination {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1rem;
+}
+
+.date-range {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.date-range input {
+  width: auto;
+  background: transparent;
+  border: none;
+}
+
+.dashboard-hero {
+  position: relative;
+  overflow: hidden;
+  border-radius: var(--radius);
+  min-height: 220px;
+  display: flex;
+  align-items: center;
+  padding: 2.5rem;
+  color: #fff;
+}
+
+.dashboard-hero .hero-bg {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(124, 58, 237, 0.4), transparent 55%), radial-gradient(circle at 80% 30%, rgba(34, 197, 94, 0.35), transparent 60%), radial-gradient(circle at 50% 80%, rgba(59, 130, 246, 0.35), transparent 70%);
+  transform: translate3d(0, 0, 0);
+}
+
+.dashboard-hero .hero-content {
+  position: relative;
+  z-index: 1;
+  max-width: 460px;
+}
+
+.dashboard-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+  margin-top: 1.5rem;
+}
+
+.dashboard-charts {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 1.5rem;
+}
+
+.kpi {
+  font-size: 2rem;
+  font-weight: 700;
+}
+
+.kpi.positive { color: var(--accent); }
+.kpi.negative { color: var(--danger); }
+.kpi.neutral { color: var(--primary); }
+
+.report-summary {
+  display: grid;
+  gap: 1rem;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.report-section {
+  display: grid;
+  gap: 1rem;
+}
+
+.report-section h2 {
+  font-size: 1.4rem;
+}
+
+.profile-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  background: var(--chip-color, rgba(255, 255, 255, 0.08));
+  color: #fff;
+  font-size: 0.8rem;
+}
+
+.card {
+  background: var(--card);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  display: grid;
+  gap: 1rem;
+  box-shadow: var(--shadow);
+  transition: transform 0.4s ease, box-shadow 0.4s ease;
+}
+
+.card-interactive:hover {
+  box-shadow: 0 24px 45px rgba(124, 58, 237, 0.3);
+}
+
+.card-header h3 {
+  font-size: 1.2rem;
+}
+
+.card-subtitle {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.chart {
+  width: 100%;
+  min-height: 260px;
+}
+
+.chart-canvas {
+  width: 100%;
+  height: 100%;
+}
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(11, 15, 20, 0.75);
+  display: grid;
+  place-items: center;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+  z-index: 9500;
+}
+
+.modal-overlay.is-open {
+  opacity: 1;
+}
+
+.modal {
+  background: var(--card);
+  border-radius: var(--radius);
+  width: min(520px, 90vw);
+  max-height: 90vh;
+  overflow-y: auto;
+  display: grid;
+  gap: 1rem;
+  padding: 1.5rem;
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.modal-close {
+  background: transparent;
+  font-size: 1.5rem;
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.toast-root {
+  pointer-events: none;
+}
+
+.toast button {
+  pointer-events: auto;
+}
+
+.table .empty-state {
+  text-align: center;
+  color: var(--muted);
+}
+
+.table th.sortable {
+  cursor: pointer;
+}
+
+.table th.sortable::after {
+  content: '⇅';
+  margin-left: 0.35rem;
+  font-size: 0.8rem;
+}
+
+@media (max-width: 1024px) {
+  .app-layout {
+    grid-template-columns: 1fr;
+  }
+  .app-sidebar {
+    position: fixed;
+    inset: 0 auto 0 0;
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
+    z-index: 1200;
+  }
+  .app-sidebar.collapsed {
+    transform: translateX(0);
+  }
+  .app-content {
+    margin-left: 0;
+  }
+}
+
+@media (max-width: 768px) {
+  .app-navbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .search-field input {
+    width: 100%;
+  }
+  .view-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}

--- a/financas-pessoais-pro-web/src/styles/themes.css
+++ b/financas-pessoais-pro-web/src/styles/themes.css
@@ -1,0 +1,37 @@
+html[data-theme='dark'] body {
+  background-color: var(--bg);
+  color: var(--text);
+}
+
+html[data-theme='light'] body {
+  background-color: var(--bg);
+  color: var(--text);
+}
+
+html[data-theme='light'] .glass {
+  border: 1px solid rgba(99, 102, 241, 0.1);
+}
+
+html[data-theme='light'] .app-sidebar {
+  background: rgba(255, 255, 255, 0.8);
+}
+
+html[data-theme='light'] .app-navbar {
+  background: rgba(255, 255, 255, 0.85);
+}
+
+html[data-theme='dark'] .app-sidebar,
+html[data-theme='dark'] .app-navbar {
+  background: rgba(15, 23, 32, 0.8);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/financas-pessoais-pro-web/src/sw.js
+++ b/financas-pessoais-pro-web/src/sw.js
@@ -1,0 +1,37 @@
+const CACHE_NAME = 'fp-pro-cache-v1';
+const ASSETS = [
+  '/public/index.html',
+  '/public/manifest.webmanifest',
+  '/public/icons/logo.svg',
+  '/src/styles/base.css',
+  '/src/styles/layout.css',
+  '/src/styles/components.css',
+  '/src/styles/animations.css',
+  '/src/styles/themes.css',
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS)).then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) => Promise.all(keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key))))
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    fetch(event.request)
+      .then((response) => {
+        const clone = response.clone();
+        caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
+        return response;
+      })
+      .catch(() => caches.match(event.request))
+  );
+});

--- a/financas-pessoais-pro-web/src/utils/dom.js
+++ b/financas-pessoais-pro-web/src/utils/dom.js
@@ -1,0 +1,96 @@
+// Helpers de DOM para facilitar criação e manipulação de elementos
+export const qs = (selector, scope = document) => scope.querySelector(selector);
+export const qsa = (selector, scope = document) => [...scope.querySelectorAll(selector)];
+
+export const el = (tag, options = {}) => {
+  const element = document.createElement(tag);
+  Object.entries(options).forEach(([key, value]) => {
+    if (key === 'class') {
+      element.className = value;
+    } else if (key === 'dataset') {
+      Object.assign(element.dataset, value);
+    } else if (key === 'text') {
+      element.textContent = value;
+    } else if (key === 'html') {
+      element.innerHTML = value;
+    } else if (key === 'attrs') {
+      Object.entries(value).forEach(([attr, val]) => {
+        element.setAttribute(attr, val);
+      });
+    } else if (key === 'children' && Array.isArray(value)) {
+      value.forEach((child) => child && element.appendChild(child));
+    } else if (key in element) {
+      element[key] = value;
+    }
+  });
+  return element;
+};
+
+export const fragment = (nodes = []) => {
+  const frag = document.createDocumentFragment();
+  nodes.forEach((node) => node && frag.appendChild(node));
+  return frag;
+};
+
+export const mount = (target, node) => {
+  if (typeof target === 'string') {
+    const found = qs(target);
+    if (!found) return null;
+    found.appendChild(node);
+    return node;
+  }
+  target.appendChild(node);
+  return node;
+};
+
+export const unmount = (node) => {
+  if (node && node.parentNode) {
+    node.parentNode.removeChild(node);
+  }
+};
+
+export const delegate = (element, selector, eventName, handler) => {
+  element.addEventListener(eventName, (event) => {
+    const potentialTargets = qsa(selector, element);
+    const target = event.target.closest(selector);
+    if (potentialTargets.includes(target)) {
+      handler.call(target, event, target);
+    }
+  });
+};
+
+export const escapeHTML = (value = '') => value
+  .replace(/&/g, '&amp;')
+  .replace(/</g, '&lt;')
+  .replace(/>/g, '&gt;')
+  .replace(/"/g, '&quot;')
+  .replace(/'/g, '&#039;');
+
+export const focusTrap = (container) => {
+  const focusableSelectors = [
+    'a[href]',
+    'button:not([disabled])',
+    'textarea:not([disabled])',
+    'input:not([disabled])',
+    'select:not([disabled])',
+    '[tabindex]:not([tabindex="-1"])',
+  ];
+  const getFocusable = () => qsa(focusableSelectors.join(','), container);
+
+  const handleKeyDown = (event) => {
+    if (event.key !== 'Tab') return;
+    const focusables = getFocusable();
+    if (!focusables.length) return;
+    const [first, last] = [focusables[0], focusables[focusables.length - 1]];
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+
+  container.addEventListener('keydown', handleKeyDown);
+  return () => container.removeEventListener('keydown', handleKeyDown);
+};

--- a/financas-pessoais-pro-web/src/utils/format.js
+++ b/financas-pessoais-pro-web/src/utils/format.js
@@ -1,0 +1,55 @@
+// Utilidades de formatação para valores monetários, datas e percentuais
+const currencyFormatter = new Intl.NumberFormat('pt-BR', {
+  style: 'currency',
+  currency: 'BRL',
+  minimumFractionDigits: 2,
+});
+
+const percentFormatter = new Intl.NumberFormat('pt-BR', {
+  style: 'percent',
+  minimumFractionDigits: 2,
+});
+
+export const formatCurrency = (value = 0) => currencyFormatter.format(Number(value) || 0);
+export const formatPercent = (value = 0) => percentFormatter.format(Number(value) || 0);
+
+export const formatDate = (isoString) => {
+  if (!isoString) return '';
+  const date = new Date(isoString);
+  return date.toLocaleDateString('pt-BR', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  });
+};
+
+export const formatDateTime = (isoString) => {
+  if (!isoString) return '';
+  const date = new Date(isoString);
+  return `${date.toLocaleDateString('pt-BR')} ${date.toLocaleTimeString('pt-BR', {
+    hour: '2-digit',
+    minute: '2-digit',
+  })}`;
+};
+
+export const toISODate = (value) => {
+  if (!value) return null;
+  const date = new Date(value);
+  return date.toISOString().slice(0, 10);
+};
+
+export const toISODateTime = (value) => {
+  if (!value) return null;
+  const date = new Date(value);
+  return date.toISOString();
+};
+
+export const maskCurrency = (input, locale = 'pt-BR', currency = 'BRL') => {
+  const digits = input.replace(/\D/g, '');
+  const number = Number(digits) / 100;
+  return new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency,
+    minimumFractionDigits: 2,
+  }).format(number);
+};

--- a/financas-pessoais-pro-web/src/utils/validate.js
+++ b/financas-pessoais-pro-web/src/utils/validate.js
@@ -1,0 +1,23 @@
+// Funções básicas de validação de formulários
+export const isEmail = (value = '') => /\S+@\S+\.\S+/.test(value);
+export const minLength = (value = '', length = 0) => value.trim().length >= length;
+export const isRequired = (value = '') => value.trim().length > 0;
+export const match = (value, other) => value === other;
+
+export const validateForm = (fields) => {
+  const errors = {};
+  Object.entries(fields).forEach(([name, validators]) => {
+    validators.some((validator) => {
+      const { rule, message } = validator;
+      if (!rule()) {
+        errors[name] = message;
+        return true;
+      }
+      return false;
+    });
+  });
+  return {
+    valid: Object.keys(errors).length === 0,
+    errors,
+  };
+};

--- a/financas-pessoais-pro-web/src/views/AccountsView.js
+++ b/financas-pessoais-pro-web/src/views/AccountsView.js
@@ -1,0 +1,182 @@
+import { el } from '../utils/dom.js';
+import Navbar from '../components/Navbar.js';
+import Sidebar from '../components/Sidebar.js';
+import Table from '../components/Table.js';
+import Modal from '../components/Modal.js';
+import Toast from '../components/Toast.js';
+import Loader from '../components/Loader.js';
+import { formatCurrency } from '../utils/format.js';
+import { accountsApi } from '../api/endpoints.js';
+import store from '../state/store.js';
+
+const AccountsView = () => {
+  const createLayout = () => {
+    const sidebar = Sidebar();
+    const navbar = Navbar();
+    const main = el('main', { class: 'app-main', attrs: { tabindex: '-1' } });
+    const contentWrapper = el('div', { class: 'app-content', children: [navbar, main] });
+    const layout = el('div', { class: 'app-layout', children: [sidebar, contentWrapper] });
+    return { layout, main };
+  };
+
+  const { layout, main } = createLayout();
+
+  const header = el('header', {
+    class: 'view-header',
+    children: [
+      el('div', {
+        children: [
+          el('h1', { text: 'Contas' }),
+          el('p', { class: 'muted', text: 'Gerencie suas contas bancárias e carteiras.' }),
+        ],
+      }),
+      el('button', { class: 'btn primary', text: 'Nova conta', attrs: { type: 'button' } }),
+    ],
+  });
+
+  const table = Table({
+    columns: [
+      { key: 'name', label: 'Nome', sortable: true },
+      { key: 'balance', label: 'Saldo', sortable: true, render: (value) => formatCurrency(value) },
+      {
+        key: 'actions',
+        label: 'Ações',
+        render: (_, item) => {
+          const wrapper = el('div', { class: 'table-actions' });
+          const edit = el('button', { class: 'btn ghost', text: 'Editar', attrs: { type: 'button' } });
+          const remove = el('button', { class: 'btn ghost danger', text: 'Excluir', attrs: { type: 'button' } });
+          edit.addEventListener('click', (event) => {
+            event.stopPropagation();
+            openForm(item);
+          });
+          remove.addEventListener('click', (event) => {
+            event.stopPropagation();
+            confirmDelete(item);
+          });
+          wrapper.append(edit, remove);
+          return wrapper;
+        },
+      },
+    ],
+    data: [],
+  });
+
+  main.append(header, table.element);
+
+  const loadAccounts = async () => {
+    try {
+      Loader.show();
+      const accounts = await accountsApi.list();
+      table.update(accounts);
+    } catch (error) {
+      Toast.show({ message: error.message || 'Erro ao carregar contas.', type: 'danger' });
+    } finally {
+      Loader.hide();
+    }
+  };
+
+  const openForm = (account = null) => {
+    const nameInput = el('input', {
+      type: 'text',
+      value: account?.name ?? '',
+      attrs: { placeholder: 'Nome da conta', required: 'true' },
+    });
+    const balanceInput = el('input', {
+      type: 'number',
+      value: account?.balance ?? 0,
+      attrs: { placeholder: 'Saldo inicial', step: '0.01' },
+    });
+    const formContent = el('div', {
+      class: 'form-grid',
+      children: [
+        el('label', { text: 'Nome', children: [nameInput] }),
+        el('label', { text: 'Saldo inicial', children: [balanceInput] }),
+      ],
+    });
+
+    const modal = Modal({
+      title: account ? 'Editar conta' : 'Nova conta',
+      content: formContent,
+      actions: [
+        {
+          label: 'Cancelar',
+          class: 'ghost',
+          onClick: ({ close }) => close(),
+        },
+        {
+          label: account ? 'Atualizar' : 'Criar',
+          class: 'primary',
+          onClick: async ({ close }) => {
+            if (!nameInput.value.trim()) {
+              Toast.show({ message: 'Informe o nome da conta.', type: 'danger' });
+              return;
+            }
+            try {
+              Loader.show();
+              if (account) {
+                await accountsApi.update(account.id, { name: nameInput.value, balance: Number(balanceInput.value) });
+                Toast.show({ message: 'Conta atualizada!', type: 'success' });
+              } else {
+                await accountsApi.create({ name: nameInput.value, balance: Number(balanceInput.value) });
+                Toast.show({ message: 'Conta criada com sucesso!', type: 'success' });
+              }
+              close();
+              loadAccounts();
+            } catch (error) {
+              Toast.show({ message: error.message || 'Erro ao salvar conta.', type: 'danger' });
+            } finally {
+              Loader.hide();
+            }
+          },
+        },
+      ],
+    });
+
+    document.getElementById('modal-root').appendChild(modal.element);
+  };
+
+  const confirmDelete = (account) => {
+    const content = el('p', { text: `Deseja realmente excluir a conta ${account.name}?` });
+    const modal = Modal({
+      title: 'Excluir conta',
+      content,
+      actions: [
+        { label: 'Cancelar', class: 'ghost', onClick: ({ close }) => close() },
+        {
+          label: 'Excluir',
+          class: 'danger',
+          onClick: async ({ close }) => {
+            try {
+              Loader.show();
+              await accountsApi.remove(account.id);
+              Toast.show({ message: 'Conta removida!', type: 'success' });
+              close();
+              loadAccounts();
+            } catch (error) {
+              Toast.show({
+                message: error.status === 409 ? 'Conta vinculada a transações. Ajuste antes de excluir.' : (error.message || 'Erro ao remover conta.'),
+                type: 'danger',
+              });
+            } finally {
+              Loader.hide();
+            }
+          },
+        },
+      ],
+    });
+    document.getElementById('modal-root').appendChild(modal.element);
+  };
+
+  header.querySelector('button').addEventListener('click', () => openForm());
+
+  store.subscribe('ui:search', (term) => table.filter(term));
+
+  return {
+    render: async () => {
+      await loadAccounts();
+      return layout;
+    },
+  };
+};
+
+export default AccountsView;

--- a/financas-pessoais-pro-web/src/views/BudgetsView.js
+++ b/financas-pessoais-pro-web/src/views/BudgetsView.js
@@ -1,0 +1,177 @@
+import { el } from '../utils/dom.js';
+import Navbar from '../components/Navbar.js';
+import Sidebar from '../components/Sidebar.js';
+import Table from '../components/Table.js';
+import Modal from '../components/Modal.js';
+import Toast from '../components/Toast.js';
+import Loader from '../components/Loader.js';
+import confetti from '../effects/confetti.js';
+import { formatCurrency } from '../utils/format.js';
+import { categoriesApi, budgetsApi } from '../api/endpoints.js';
+import store from '../state/store.js';
+
+const BudgetsView = () => {
+  const sidebar = Sidebar();
+  const navbar = Navbar();
+  const main = el('main', { class: 'app-main', attrs: { tabindex: '-1' } });
+  const layout = el('div', { class: 'app-layout', children: [sidebar, el('div', { class: 'app-content', children: [navbar, main] })] });
+
+  const header = el('header', {
+    class: 'view-header',
+    children: [
+      el('div', { children: [el('h1', { text: 'Metas e Orçamentos' }), el('p', { class: 'muted', text: 'Defina limites por categoria e acompanhe o progresso.' })] }),
+      el('button', { class: 'btn primary', text: 'Nova meta', attrs: { type: 'button' } }),
+    ],
+  });
+
+  const monthInput = el('input', { type: 'month', value: new Date().toISOString().slice(0, 7) });
+  const controls = el('div', { class: 'panel controls', children: [el('label', { text: 'Mês', children: [monthInput] })] });
+
+  const table = Table({
+    columns: [
+      { key: 'categoryName', label: 'Categoria', sortable: true },
+      { key: 'amount', label: 'Meta', sortable: true, render: (value) => formatCurrency(value) },
+      { key: 'spent', label: 'Gasto', sortable: true, render: (value) => formatCurrency(value) },
+      {
+        key: 'progress',
+        label: 'Progresso',
+        render: (value, item) => {
+          const percent = Math.min(150, Math.round((item.spent / item.amount) * 100 || 0));
+          const bar = el('div', { class: 'progress-bar' });
+          bar.style.setProperty('--progress', `${percent}`);
+          bar.title = `${percent}%`;
+          return bar;
+        },
+      },
+      {
+        key: 'actions',
+        label: 'Ações',
+        render: (_, item) => {
+          const wrapper = el('div', { class: 'table-actions' });
+          const edit = el('button', { class: 'btn ghost', text: 'Editar', attrs: { type: 'button' } });
+          const remove = el('button', { class: 'btn ghost danger', text: 'Excluir', attrs: { type: 'button' } });
+          edit.addEventListener('click', (event) => {
+            event.stopPropagation();
+            openForm(item);
+          });
+          remove.addEventListener('click', async (event) => {
+            event.stopPropagation();
+            try {
+              Loader.show();
+              await budgetsApi.remove(item.id);
+              Toast.show({ message: 'Meta removida.', type: 'success' });
+              loadBudgets();
+            } catch (error) {
+              Toast.show({ message: error.message || 'Erro ao remover meta.', type: 'danger' });
+            } finally {
+              Loader.hide();
+            }
+          });
+          wrapper.append(edit, remove);
+          return wrapper;
+        },
+      },
+    ],
+  });
+
+  main.append(header, controls, table.element);
+
+  let categories = [];
+
+  const loadCategories = async () => {
+    categories = await categoriesApi.list();
+  };
+
+  const loadBudgets = async () => {
+    try {
+      Loader.show();
+      const month = `${monthInput.value}-01`;
+      const budgets = await budgetsApi.list({ month });
+      const formatted = budgets.map((budget) => ({
+        ...budget,
+        categoryName: budget.category?.name ?? '-',
+        categoryId: budget.category?.id,
+        spent: budget.spent ?? 0,
+        amount: budget.amount ?? 0,
+      }));
+      table.update(formatted);
+      formatted.forEach((budget) => {
+        const percent = (budget.spent / (budget.amount || 1)) * 100;
+        if (percent >= 100) {
+          Toast.show({ message: `${budget.categoryName} atingiu ou ultrapassou a meta!`, type: 'warning' });
+          confetti();
+        }
+      });
+    } catch (error) {
+      Toast.show({ message: error.message || 'Erro ao carregar metas.', type: 'danger' });
+    } finally {
+      Loader.hide();
+    }
+  };
+
+  const openForm = (budget = null) => {
+    const form = el('form', {
+      class: 'form-grid',
+      children: [
+        el('label', { text: 'Categoria', children: [el('select', { id: 'budget-category', children: categories.map((category) => el('option', { value: category.id, text: category.name })) })] }),
+        el('label', { text: 'Mês', children: [el('input', { type: 'month', id: 'budget-month', value: budget ? budget.month?.slice(0, 7) : monthInput.value })] }),
+        el('label', { text: 'Valor', children: [el('input', { type: 'number', step: '0.01', id: 'budget-amount', value: budget?.amount ?? 0 })] }),
+      ],
+    });
+
+    const categorySelect = form.querySelector('#budget-category');
+    if (budget) {
+      categorySelect.value = budget.categoryId;
+    }
+
+    const modal = Modal({
+      title: budget ? 'Editar meta' : 'Nova meta',
+      content: form,
+      actions: [
+        { label: 'Cancelar', class: 'ghost', onClick: ({ close }) => close() },
+        {
+          label: budget ? 'Atualizar' : 'Criar',
+          class: 'primary',
+          onClick: async ({ close }) => {
+            const payload = {
+              categoryId: categorySelect.value,
+              month: `${form.querySelector('#budget-month').value}-01`,
+              amount: Number(form.querySelector('#budget-amount').value),
+            };
+            try {
+              Loader.show();
+              if (budget) {
+                await budgetsApi.update(budget.id, payload);
+                Toast.show({ message: 'Meta atualizada.', type: 'success' });
+              } else {
+                await budgetsApi.create(payload);
+                Toast.show({ message: 'Meta criada.', type: 'success' });
+              }
+              close();
+              loadBudgets();
+            } catch (error) {
+              Toast.show({ message: error.message || 'Erro ao salvar meta.', type: 'danger' });
+            } finally {
+              Loader.hide();
+            }
+          },
+        },
+      ],
+    });
+    document.getElementById('modal-root').appendChild(modal.element);
+  };
+
+  header.querySelector('button').addEventListener('click', () => openForm());
+  monthInput.addEventListener('change', loadBudgets);
+  store.subscribe('ui:search', (term) => table.filter(term));
+
+  return {
+    render: async () => {
+      await loadCategories();
+      await loadBudgets();
+      return layout;
+    },
+  };
+};
+
+export default BudgetsView;

--- a/financas-pessoais-pro-web/src/views/CategoriesView.js
+++ b/financas-pessoais-pro-web/src/views/CategoriesView.js
@@ -1,0 +1,186 @@
+import { el } from '../utils/dom.js';
+import Navbar from '../components/Navbar.js';
+import Sidebar from '../components/Sidebar.js';
+import Table from '../components/Table.js';
+import Modal from '../components/Modal.js';
+import Chip from '../components/Chip.js';
+import Toast from '../components/Toast.js';
+import Loader from '../components/Loader.js';
+import { categoriesApi } from '../api/endpoints.js';
+import store from '../state/store.js';
+
+const CategoriesView = () => {
+  const { layout, main } = (() => {
+    const sidebar = Sidebar();
+    const navbar = Navbar();
+    const mainEl = el('main', { class: 'app-main', attrs: { tabindex: '-1' } });
+    const contentWrapper = el('div', { class: 'app-content', children: [navbar, mainEl] });
+    return { layout: el('div', { class: 'app-layout', children: [sidebar, contentWrapper] }), main: mainEl };
+  })();
+
+  const header = el('header', {
+    class: 'view-header',
+    children: [
+      el('div', {
+        children: [
+          el('h1', { text: 'Categorias' }),
+          el('p', { class: 'muted', text: 'Organize suas categorias de receitas e despesas.' }),
+        ],
+      }),
+      el('button', { class: 'btn primary', text: 'Nova categoria', attrs: { type: 'button' } }),
+    ],
+  });
+
+  const table = Table({
+    columns: [
+      { key: 'name', label: 'Nome', sortable: true },
+      { key: 'type', label: 'Tipo', sortable: true, render: (value) => (value === 'INCOME' ? 'Entrada' : 'Saída') },
+      {
+        key: 'color',
+        label: 'Cor',
+        render: (value, item) => Chip({ label: item.name, color: value }),
+      },
+      {
+        key: 'actions',
+        label: 'Ações',
+        render: (_, item) => {
+          const wrapper = el('div', { class: 'table-actions' });
+          const edit = el('button', { class: 'btn ghost', text: 'Editar', attrs: { type: 'button' } });
+          const remove = el('button', { class: 'btn ghost danger', text: 'Excluir', attrs: { type: 'button' } });
+          edit.addEventListener('click', (event) => {
+            event.stopPropagation();
+            openForm(item);
+          });
+          remove.addEventListener('click', (event) => {
+            event.stopPropagation();
+            confirmDelete(item);
+          });
+          wrapper.append(edit, remove);
+          return wrapper;
+        },
+      },
+    ],
+    data: [],
+  });
+
+  main.append(header, table.element);
+
+  const loadCategories = async () => {
+    try {
+      Loader.show();
+      const categories = await categoriesApi.list();
+      table.update(categories);
+    } catch (error) {
+      Toast.show({ message: error.message || 'Erro ao carregar categorias.', type: 'danger' });
+    } finally {
+      Loader.hide();
+    }
+  };
+
+  const openForm = (category = null) => {
+    const nameInput = el('input', {
+      type: 'text',
+      value: category?.name ?? '',
+      attrs: { placeholder: 'Nome da categoria', required: 'true' },
+    });
+    const typeSelect = el('select', {
+      children: [
+        el('option', { value: 'INCOME', text: 'Entrada' }),
+        el('option', { value: 'EXPENSE', text: 'Saída' }),
+      ],
+    });
+    typeSelect.value = category?.type ?? 'EXPENSE';
+    const colorInput = el('input', { type: 'color', value: category?.color ?? '#7c3aed' });
+
+    const formContent = el('div', {
+      class: 'form-grid',
+      children: [
+        el('label', { text: 'Nome', children: [nameInput] }),
+        el('label', { text: 'Tipo', children: [typeSelect] }),
+        el('label', { text: 'Cor', children: [colorInput] }),
+      ],
+    });
+
+    const modal = Modal({
+      title: category ? 'Editar categoria' : 'Nova categoria',
+      content: formContent,
+      actions: [
+        { label: 'Cancelar', class: 'ghost', onClick: ({ close }) => close() },
+        {
+          label: category ? 'Atualizar' : 'Criar',
+          class: 'primary',
+          onClick: async ({ close }) => {
+            if (!nameInput.value.trim()) {
+              Toast.show({ message: 'Informe o nome da categoria.', type: 'danger' });
+              return;
+            }
+            try {
+              Loader.show();
+              const payload = { name: nameInput.value, type: typeSelect.value, color: colorInput.value };
+              if (category) {
+                await categoriesApi.update(category.id, payload);
+                Toast.show({ message: 'Categoria atualizada!', type: 'success' });
+              } else {
+                await categoriesApi.create(payload);
+                Toast.show({ message: 'Categoria criada!', type: 'success' });
+              }
+              close();
+              loadCategories();
+            } catch (error) {
+              Toast.show({
+                message: error.status === 409 ? 'Nome já utilizado. Escolha outro.' : (error.message || 'Erro ao salvar categoria.'),
+                type: 'danger',
+              });
+            } finally {
+              Loader.hide();
+            }
+          },
+        },
+      ],
+    });
+    document.getElementById('modal-root').appendChild(modal.element);
+  };
+
+  const confirmDelete = (category) => {
+    const modal = Modal({
+      title: 'Excluir categoria',
+      content: el('p', { text: `Excluir a categoria ${category.name}?` }),
+      actions: [
+        { label: 'Cancelar', class: 'ghost', onClick: ({ close }) => close() },
+        {
+          label: 'Excluir',
+          class: 'danger',
+          onClick: async ({ close }) => {
+            try {
+              Loader.show();
+              await categoriesApi.remove(category.id);
+              Toast.show({ message: 'Categoria removida.', type: 'success' });
+              close();
+              loadCategories();
+            } catch (error) {
+              Toast.show({
+                message: error.status === 409 ? 'Categoria utilizada em lançamentos. Atualize-os antes de excluir.' : (error.message || 'Erro ao remover categoria.'),
+                type: 'danger',
+              });
+            } finally {
+              Loader.hide();
+            }
+          },
+        },
+      ],
+    });
+    document.getElementById('modal-root').appendChild(modal.element);
+  };
+
+  header.querySelector('button').addEventListener('click', () => openForm());
+  store.subscribe('ui:search', (term) => table.filter(term));
+
+  return {
+    render: async () => {
+      await loadCategories();
+      return layout;
+    },
+  };
+};
+
+export default CategoriesView;

--- a/financas-pessoais-pro-web/src/views/DashboardView.js
+++ b/financas-pessoais-pro-web/src/views/DashboardView.js
@@ -1,0 +1,158 @@
+import { el } from '../utils/dom.js';
+import Navbar from '../components/Navbar.js';
+import Sidebar from '../components/Sidebar.js';
+import Card from '../components/Card.js';
+import DateRange from '../components/DateRange.js';
+import Chart from '../components/Chart.js';
+import Loader from '../components/Loader.js';
+import Toast from '../components/Toast.js';
+import parallax from '../effects/parallax.js';
+import { formatCurrency } from '../utils/format.js';
+import { getSummary, getCashflowDaily, getByCategory } from '../api/endpoints.js';
+import store from '../state/store.js';
+
+const DashboardView = () => {
+  const createLayout = () => {
+    const sidebar = Sidebar();
+    const navbar = Navbar();
+    const main = el('main', { class: 'app-main', attrs: { tabindex: '-1' } });
+    const contentWrapper = el('div', { class: 'app-content', children: [navbar, main] });
+    const layout = el('div', { class: 'app-layout dashboard', children: [sidebar, contentWrapper] });
+    return { layout, main };
+  };
+
+  const { layout, main } = createLayout();
+
+  const now = new Date();
+  const from = new Date(now.getFullYear(), now.getMonth(), 1).toISOString().slice(0, 10);
+  const to = new Date(now.getFullYear(), now.getMonth() + 1, 0).toISOString().slice(0, 10);
+
+  const header = el('section', {
+    class: 'dashboard-hero',
+    children: [
+      el('div', {
+        class: 'hero-bg',
+      }),
+      el('div', {
+        class: 'hero-content',
+        children: [
+          el('h1', { text: 'Olá! Vamos dominar suas finanças.' }),
+          el('p', { text: 'Visualize seus KPIs, cashflow diário e despesas por categoria.' }),
+        ],
+      }),
+    ],
+  });
+
+  let currentRange = { from, to };
+  const rangePicker = DateRange({
+    from,
+    to,
+    onChange: ({ from: f, to: t }) => {
+      currentRange = { from: f, to: t };
+      loadData(f, t);
+    },
+  });
+
+  const summaryContainer = el('div', { class: 'dashboard-cards' });
+  const chartsContainer = el('div', { class: 'dashboard-charts' });
+
+  const cashflowChart = Chart({ type: 'line' });
+  const categoryChart = Chart({ type: 'bar' });
+
+  chartsContainer.append(
+    Card({
+      title: 'Cashflow diário',
+      subtitle: 'Entradas x Saídas',
+      content: cashflowChart.element,
+    }),
+    Card({
+      title: 'Gastos por categoria',
+      subtitle: 'Último período selecionado',
+      content: categoryChart.element,
+    })
+  );
+
+  main.append(header, el('section', { class: 'panel', children: [rangePicker.element, summaryContainer] }), chartsContainer);
+
+  const renderSummary = (summary) => {
+    summaryContainer.innerHTML = '';
+    const cards = [
+      { title: 'Total recebido', value: summary.totalIn, accent: 'positive' },
+      { title: 'Total gasto', value: summary.totalOut, accent: 'negative' },
+      { title: 'Saldo atual', value: summary.balance, accent: 'neutral' },
+    ];
+    cards.forEach((card) => {
+      summaryContainer.append(
+        Card({
+          title: card.title,
+          subtitle: 'Período selecionado',
+          content: el('p', { class: `kpi ${card.accent}`, text: formatCurrency(card.value) }),
+        })
+      );
+    });
+  };
+
+  const loadData = async (fromDate, toDate) => {
+    try {
+      Loader.show();
+      const [summary, cashflow, byCategory] = await Promise.all([
+        getSummary({ from: fromDate, to: toDate }),
+        getCashflowDaily({ from: fromDate, to: toDate }),
+        getByCategory({ from: fromDate, to: toDate }),
+      ]);
+      renderSummary(summary);
+
+      cashflowChart.update({
+        type: 'line',
+        data: {
+          labels: cashflow.map((item) => item.date),
+          datasets: [
+            {
+              data: cashflow.map((item) => item.balance),
+              borderColor: '#7c3aed',
+            },
+          ],
+        },
+      });
+
+      categoryChart.update({
+        type: 'bar',
+        data: {
+          labels: byCategory.map((item) => item.category),
+          datasets: [
+            {
+              data: byCategory.map((item) => Math.abs(item.amount)),
+              backgroundColor: byCategory.map((item) => item.color || '#7c3aed'),
+            },
+          ],
+        },
+      });
+    } catch (error) {
+      Toast.show({ message: error.message || 'Erro ao carregar dashboard.', type: 'danger' });
+    } finally {
+      Loader.hide();
+    }
+  };
+
+  parallax(header.querySelector('.hero-bg'));
+
+  const unsubscribe = store.subscribe('dashboard:refresh', () => {
+    loadData(currentRange.from, currentRange.to);
+  });
+
+  const destroy = () => {
+    store.set('ui:search', '');
+    unsubscribe();
+  };
+
+  return {
+    render: async () => {
+      currentRange = { from, to };
+      await loadData(from, to);
+      return layout;
+    },
+    destroy,
+  };
+};
+
+export default DashboardView;

--- a/financas-pessoais-pro-web/src/views/LoginView.js
+++ b/financas-pessoais-pro-web/src/views/LoginView.js
@@ -1,0 +1,101 @@
+import { el } from '../utils/dom.js';
+import { isEmail, minLength, validateForm } from '../utils/validate.js';
+import { login } from '../api/endpoints.js';
+import auth from '../state/auth.js';
+import router from '../router.js';
+import Toast from '../components/Toast.js';
+import Loader from '../components/Loader.js';
+
+const LoginView = () => {
+  const container = el('div', { class: 'auth-view' });
+
+  const emailInput = el('input', {
+    type: 'email',
+    id: 'login-email',
+    required: true,
+    attrs: { autocomplete: 'email', placeholder: ' ' },
+  });
+
+  const passwordInput = el('input', {
+    type: 'password',
+    id: 'login-password',
+    required: true,
+    attrs: { autocomplete: 'current-password', placeholder: ' ' },
+  });
+
+  const showPassword = el('button', {
+    class: 'btn ghost',
+    text: 'Mostrar',
+    attrs: { type: 'button' },
+  });
+
+  const rememberInput = el('input', { type: 'checkbox', id: 'remember-me' });
+
+  const form = el('form', {
+    class: 'auth-card glass',
+    attrs: { novalidate: 'true' },
+    children: [
+      el('h1', { text: 'Bem-vindo de volta!' }),
+      el('p', { class: 'muted', text: 'Entre para acessar seu painel financeiro.' }),
+      el('label', { class: 'floating', attrs: { for: 'login-email' }, children: [emailInput, el('span', { text: 'E-mail' })] }),
+      el('label', { class: 'floating', attrs: { for: 'login-password' }, children: [passwordInput, el('span', { text: 'Senha' })] }),
+      el('div', { class: 'form-row', children: [
+        el('label', { class: 'checkbox', attrs: { for: 'remember-me' }, children: [rememberInput, el('span', { text: 'Lembrar de mim' })] }),
+        showPassword,
+      ] }),
+      el('button', { class: 'btn primary', text: 'Entrar', attrs: { type: 'submit' } }),
+      el('p', {
+        class: 'muted',
+        html: 'Não possui conta? <a href="#/signup">Cadastre-se</a>',
+      }),
+    ],
+  });
+
+  showPassword.addEventListener('click', () => {
+    const isPassword = passwordInput.type === 'password';
+    passwordInput.type = isPassword ? 'text' : 'password';
+    showPassword.textContent = isPassword ? 'Ocultar' : 'Mostrar';
+  });
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const { valid, errors } = validateForm({
+      email: [
+        { rule: () => isEmail(emailInput.value), message: 'Informe um e-mail válido.' },
+      ],
+      password: [
+        { rule: () => minLength(passwordInput.value, 8), message: 'A senha deve possuir ao menos 8 caracteres.' },
+      ],
+    });
+
+    if (!valid) {
+      Toast.show({ message: Object.values(errors)[0], type: 'danger' });
+      form.classList.add('shake');
+      setTimeout(() => form.classList.remove('shake'), 400);
+      return;
+    }
+
+    try {
+      Loader.show();
+      await login({ email: emailInput.value, password: passwordInput.value });
+      if (!rememberInput.checked) {
+        sessionStorage.setItem('fp:last-login-email', emailInput.value);
+      }
+      Toast.show({ message: 'Login realizado com sucesso!', type: 'success' });
+      router.go('#/dashboard');
+    } catch (error) {
+      Toast.show({ message: error.message || 'Credenciais inválidas.', type: 'danger' });
+      auth.logout();
+    } finally {
+      Loader.hide();
+    }
+  });
+
+  container.appendChild(form);
+
+  return {
+    render: async () => container,
+  };
+};
+
+export default LoginView;

--- a/financas-pessoais-pro-web/src/views/RecurringsView.js
+++ b/financas-pessoais-pro-web/src/views/RecurringsView.js
@@ -1,0 +1,189 @@
+import { el } from '../utils/dom.js';
+import Navbar from '../components/Navbar.js';
+import Sidebar from '../components/Sidebar.js';
+import Table from '../components/Table.js';
+import Modal from '../components/Modal.js';
+import Toast from '../components/Toast.js';
+import Loader from '../components/Loader.js';
+import { formatCurrency, formatDate } from '../utils/format.js';
+import { accountsApi, categoriesApi, recurringsApi } from '../api/endpoints.js';
+import store from '../state/store.js';
+
+const RecurringsView = () => {
+  const sidebar = Sidebar();
+  const navbar = Navbar();
+  const main = el('main', { class: 'app-main', attrs: { tabindex: '-1' } });
+  const layout = el('div', { class: 'app-layout', children: [sidebar, el('div', { class: 'app-content', children: [navbar, main] })] });
+
+  const header = el('header', {
+    class: 'view-header',
+    children: [
+      el('div', { children: [el('h1', { text: 'Recorrências' }), el('p', { class: 'muted', text: 'Automatize lançamentos periódicos.' })] }),
+      el('button', { class: 'btn primary', text: 'Nova regra', attrs: { type: 'button' } }),
+    ],
+  });
+
+  const table = Table({
+    columns: [
+      { key: 'descriptionTemplate', label: 'Descrição', sortable: true },
+      { key: 'account', label: 'Conta', sortable: true },
+      { key: 'category', label: 'Categoria', sortable: true },
+      { key: 'baseAmount', label: 'Valor', sortable: true, render: (value) => formatCurrency(value) },
+      { key: 'frequency', label: 'Frequência', sortable: true },
+      { key: 'nextRun', label: 'Próxima execução', sortable: true, render: (value) => formatDate(value) },
+      { key: 'active', label: 'Status', sortable: true, render: (value) => (value ? '<span class="tag positive">Ativa</span>' : '<span class="tag warning">Pausada</span>') },
+      {
+        key: 'actions',
+        label: 'Ações',
+        render: (_, item) => {
+          const wrapper = el('div', { class: 'table-actions' });
+          const edit = el('button', { class: 'btn ghost', text: 'Editar', attrs: { type: 'button' } });
+          const toggle = el('button', { class: 'btn ghost', text: item.active ? 'Pausar' : 'Retomar', attrs: { type: 'button' } });
+          const remove = el('button', { class: 'btn ghost danger', text: 'Excluir', attrs: { type: 'button' } });
+          edit.addEventListener('click', (event) => {
+            event.stopPropagation();
+            openForm(item);
+          });
+          toggle.addEventListener('click', async (event) => {
+            event.stopPropagation();
+            try {
+              Loader.show();
+              await recurringsApi.update(item.id, { active: !item.active });
+              Toast.show({ message: item.active ? 'Recorrência pausada.' : 'Recorrência retomada.', type: 'success' });
+              loadRecurrings();
+            } catch (error) {
+              Toast.show({ message: error.message || 'Erro ao atualizar regra.', type: 'danger' });
+            } finally {
+              Loader.hide();
+            }
+          });
+          remove.addEventListener('click', async (event) => {
+            event.stopPropagation();
+            try {
+              Loader.show();
+              await recurringsApi.remove(item.id);
+              Toast.show({ message: 'Regra excluída.', type: 'success' });
+              loadRecurrings();
+            } catch (error) {
+              Toast.show({ message: error.message || 'Erro ao excluir regra.', type: 'danger' });
+            } finally {
+              Loader.hide();
+            }
+          });
+          wrapper.append(edit, toggle, remove);
+          return wrapper;
+        },
+      },
+    ],
+  });
+
+  main.append(header, table.element);
+
+  let accounts = [];
+  let categories = [];
+
+  const loadDependencies = async () => {
+    const [accountsList, categoriesList] = await Promise.all([accountsApi.list(), categoriesApi.list()]);
+    accounts = accountsList;
+    categories = categoriesList;
+  };
+
+  const loadRecurrings = async () => {
+    try {
+      Loader.show();
+      const recurrings = await recurringsApi.list();
+      const mapped = recurrings.map((rule) => ({
+        ...rule,
+        account: rule.account?.name ?? '-',
+        category: rule.category?.name ?? '-',
+      }));
+      table.update(mapped);
+    } catch (error) {
+      Toast.show({ message: error.message || 'Erro ao carregar recorrências.', type: 'danger' });
+    } finally {
+      Loader.hide();
+    }
+  };
+
+  const openForm = (rule = null) => {
+    const form = el('form', {
+      class: 'form-grid',
+      children: [
+        el('label', { text: 'Conta', children: [el('select', { id: 'recurring-account', children: accounts.map((account) => el('option', { value: account.id, text: account.name })) })] }),
+        el('label', { text: 'Categoria', children: [el('select', { id: 'recurring-category', children: [el('option', { value: '', text: 'Nenhuma' }), ...categories.map((category) => el('option', { value: category.id, text: category.name }))] })] }),
+        el('label', { text: 'Tipo base', children: [el('select', { id: 'recurring-base-type', children: [el('option', { value: 'FIXED', text: 'Valor fixo' }), el('option', { value: 'PERCENT', text: 'Percentual' })] })] }),
+        el('label', { text: 'Valor base', children: [el('input', { type: 'number', step: '0.01', id: 'recurring-base-amount', value: rule?.baseAmount ?? 0 })] }),
+        el('label', { text: 'Descrição padrão', children: [el('input', { type: 'text', id: 'recurring-description', value: rule?.descriptionTemplate ?? '' })] }),
+        el('label', { text: 'Frequência', children: [el('select', { id: 'recurring-frequency', children: [el('option', { value: 'DAILY', text: 'Diário' }), el('option', { value: 'WEEKLY', text: 'Semanal' }), el('option', { value: 'MONTHLY', text: 'Mensal' }), el('option', { value: 'YEARLY', text: 'Anual' })] })] }),
+        el('label', { text: 'Próxima execução', children: [el('input', { type: 'date', id: 'recurring-next-run', value: rule?.nextRun?.slice(0, 10) ?? new Date().toISOString().slice(0, 10) })] }),
+        el('label', { text: 'Ativa', children: [el('input', { type: 'checkbox', id: 'recurring-active', checked: rule?.active ?? true })] }),
+      ],
+    });
+
+    const accountSelect = form.querySelector('#recurring-account');
+    const categorySelect = form.querySelector('#recurring-category');
+    const baseTypeSelect = form.querySelector('#recurring-base-type');
+    const frequencySelect = form.querySelector('#recurring-frequency');
+
+    if (rule) {
+      accountSelect.value = rule.account?.id;
+      categorySelect.value = rule.category?.id ?? '';
+      baseTypeSelect.value = rule.baseType;
+      frequencySelect.value = rule.frequency;
+    }
+
+    const modal = Modal({
+      title: rule ? 'Editar regra' : 'Nova regra',
+      content: form,
+      actions: [
+        { label: 'Cancelar', class: 'ghost', onClick: ({ close }) => close() },
+        {
+          label: rule ? 'Atualizar' : 'Criar',
+          class: 'primary',
+          onClick: async ({ close }) => {
+            const payload = {
+              accountId: accountSelect.value,
+              categoryId: categorySelect.value || null,
+              baseType: baseTypeSelect.value,
+              baseAmount: Number(form.querySelector('#recurring-base-amount').value),
+              descriptionTemplate: form.querySelector('#recurring-description').value,
+              frequency: frequencySelect.value,
+              nextRun: form.querySelector('#recurring-next-run').value,
+              active: form.querySelector('#recurring-active').checked,
+            };
+            try {
+              Loader.show();
+              if (rule) {
+                await recurringsApi.update(rule.id, payload);
+                Toast.show({ message: 'Regra atualizada.', type: 'success' });
+              } else {
+                await recurringsApi.create(payload);
+                Toast.show({ message: 'Regra criada.', type: 'success' });
+              }
+              close();
+              loadRecurrings();
+            } catch (error) {
+              Toast.show({ message: error.message || 'Erro ao salvar regra.', type: 'danger' });
+            } finally {
+              Loader.hide();
+            }
+          },
+        },
+      ],
+    });
+    document.getElementById('modal-root').appendChild(modal.element);
+  };
+
+  header.querySelector('button').addEventListener('click', () => openForm());
+  store.subscribe('ui:search', (term) => table.filter(term));
+
+  return {
+    render: async () => {
+      await loadDependencies();
+      await loadRecurrings();
+      return layout;
+    },
+  };
+};
+
+export default RecurringsView;

--- a/financas-pessoais-pro-web/src/views/ReportsView.js
+++ b/financas-pessoais-pro-web/src/views/ReportsView.js
@@ -1,0 +1,132 @@
+import { el } from '../utils/dom.js';
+import Navbar from '../components/Navbar.js';
+import Sidebar from '../components/Sidebar.js';
+import Table from '../components/Table.js';
+import Toast from '../components/Toast.js';
+import Loader from '../components/Loader.js';
+import { formatCurrency, formatDate } from '../utils/format.js';
+import { getSummary, getCashflowDaily, getByCategory } from '../api/endpoints.js';
+import store from '../state/store.js';
+
+const ReportsView = () => {
+  const sidebar = Sidebar();
+  const navbar = Navbar();
+  const main = el('main', { class: 'app-main', attrs: { tabindex: '-1' } });
+  const layout = el('div', { class: 'app-layout', children: [sidebar, el('div', { class: 'app-content', children: [navbar, main] })] });
+
+  const header = el('header', {
+    class: 'view-header',
+    children: [
+      el('div', { children: [el('h1', { text: 'Relatórios' }), el('p', { class: 'muted', text: 'Resumo completo das suas movimentações.' })] }),
+    ],
+  });
+
+  const dateControls = el('div', {
+    class: 'panel controls',
+    children: [
+      el('label', { text: 'De', children: [el('input', { type: 'date', id: 'reports-from' })] }),
+      el('label', { text: 'Até', children: [el('input', { type: 'date', id: 'reports-to' })] }),
+      el('button', { class: 'btn primary', text: 'Atualizar', attrs: { type: 'button', id: 'reports-refresh' } }),
+      el('button', { class: 'btn ghost', text: 'Exportar CSV', attrs: { type: 'button', id: 'reports-export' } }),
+      el('button', { class: 'btn ghost', text: 'Copiar JSON', attrs: { type: 'button', id: 'reports-copy' } }),
+    ],
+  });
+
+  const summaryCard = el('div', { class: 'report-summary panel' });
+  const cashflowTable = Table({
+    columns: [
+      { key: 'date', label: 'Data', sortable: true, render: (value) => formatDate(value) },
+      { key: 'in', label: 'Entradas', sortable: true, render: (value) => formatCurrency(value) },
+      { key: 'out', label: 'Saídas', sortable: true, render: (value) => formatCurrency(value) },
+      { key: 'balance', label: 'Saldo', sortable: true, render: (value) => formatCurrency(value) },
+    ],
+  });
+
+  const categoriesTable = Table({
+    columns: [
+      { key: 'category', label: 'Categoria', sortable: true },
+      { key: 'amount', label: 'Valor', sortable: true, render: (value) => formatCurrency(value) },
+    ],
+  });
+
+  main.append(header, dateControls, summaryCard, el('section', { class: 'report-section', children: [el('h2', { text: 'Cashflow diário' }), cashflowTable.element] }), el('section', { class: 'report-section', children: [el('h2', { text: 'Por categoria' }), categoriesTable.element] }));
+
+  const fromInput = dateControls.querySelector('#reports-from');
+  const toInput = dateControls.querySelector('#reports-to');
+
+  const today = new Date();
+  const defaultFrom = new Date(today.getFullYear(), today.getMonth(), 1).toISOString().slice(0, 10);
+  const defaultTo = today.toISOString().slice(0, 10);
+  fromInput.value = defaultFrom;
+  toInput.value = defaultTo;
+
+  let lastData = { summary: null, cashflow: [], categories: [] };
+
+  const renderSummary = (summary) => {
+    summaryCard.innerHTML = `
+      <div class="summary-grid">
+        <div><span>Total de entradas</span><strong>${formatCurrency(summary.totalIn)}</strong></div>
+        <div><span>Total de saídas</span><strong>${formatCurrency(summary.totalOut)}</strong></div>
+        <div><span>Saldo</span><strong>${formatCurrency(summary.balance)}</strong></div>
+      </div>
+    `;
+  };
+
+  const loadReports = async () => {
+    try {
+      Loader.show();
+      const params = { from: fromInput.value, to: toInput.value };
+      const [summary, cashflow, categories] = await Promise.all([
+        getSummary(params),
+        getCashflowDaily(params),
+        getByCategory(params),
+      ]);
+      lastData = { summary, cashflow, categories };
+      renderSummary(summary);
+      cashflowTable.update(cashflow);
+      categoriesTable.update(categories);
+    } catch (error) {
+      Toast.show({ message: error.message || 'Erro ao carregar relatórios.', type: 'danger' });
+    } finally {
+      Loader.hide();
+    }
+  };
+
+  const exportCSV = () => {
+    const rows = [['Tipo', 'Categoria/Data', 'Valor']];
+    lastData.categories.forEach((row) => rows.push(['Categoria', row.category, row.amount]));
+    lastData.cashflow.forEach((row) => rows.push(['Cashflow', row.date, row.balance]));
+    const csv = rows.map((row) => row.join(';')).join('\n');
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = 'relatorios.csv';
+    link.click();
+  };
+
+  const copyJSON = async () => {
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(lastData, null, 2));
+      Toast.show({ message: 'JSON copiado para a área de transferência.', type: 'success' });
+    } catch (error) {
+      Toast.show({ message: 'Não foi possível copiar.', type: 'danger' });
+    }
+  };
+
+  dateControls.querySelector('#reports-refresh').addEventListener('click', loadReports);
+  dateControls.querySelector('#reports-export').addEventListener('click', exportCSV);
+  dateControls.querySelector('#reports-copy').addEventListener('click', copyJSON);
+  store.subscribe('ui:search', (term) => {
+    cashflowTable.filter(term);
+    categoriesTable.filter(term);
+  });
+
+  return {
+    render: async () => {
+      await loadReports();
+      return layout;
+    },
+  };
+};
+
+export default ReportsView;

--- a/financas-pessoais-pro-web/src/views/SettingsView.js
+++ b/financas-pessoais-pro-web/src/views/SettingsView.js
@@ -1,0 +1,102 @@
+import { el } from '../utils/dom.js';
+import Navbar from '../components/Navbar.js';
+import Sidebar from '../components/Sidebar.js';
+import Toast from '../components/Toast.js';
+import auth from '../state/auth.js';
+import router from '../router.js';
+import store from '../state/store.js';
+import CONFIG from '../config.js';
+
+const SettingsView = () => {
+  const sidebar = Sidebar();
+  const navbar = Navbar();
+  const main = el('main', { class: 'app-main', attrs: { tabindex: '-1' } });
+  const layout = el('div', { class: 'app-layout', children: [sidebar, el('div', { class: 'app-content', children: [navbar, main] })] });
+
+  const user = auth.getUser();
+
+  const profileSection = el('section', {
+    class: 'panel',
+    children: [
+      el('h2', { text: 'Perfil' }),
+      el('dl', {
+        class: 'profile-grid',
+        html: `
+          <div><dt>Nome</dt><dd>${user?.name ?? '-'}</dd></div>
+          <div><dt>E-mail</dt><dd>${user?.email ?? '-'}</dd></div>
+        `,
+      }),
+    ],
+  });
+
+  const themeSelect = el('select', {
+    children: [
+      el('option', { value: 'light', text: 'Claro' }),
+      el('option', { value: 'dark', text: 'Escuro' }),
+      el('option', { value: 'system', text: 'Sistema' }),
+    ],
+  });
+  themeSelect.value = localStorage.getItem('fp:theme') || 'dark';
+
+  const themeSection = el('section', {
+    class: 'panel',
+    children: [
+      el('h2', { text: 'Tema' }),
+      el('p', { class: 'muted', text: 'Escolha o modo de cor preferido.' }),
+      el('label', { text: 'Tema', children: [themeSelect] }),
+    ],
+  });
+
+  const apiInput = el('input', { type: 'url', value: CONFIG.API_BASE_URL, attrs: { placeholder: 'https://sua.api/endpoint' } });
+  const apiSection = el('section', {
+    class: 'panel',
+    children: [
+      el('h2', { text: 'API' }),
+      el('p', { class: 'muted', text: 'Atualize a URL base da API caso utilize outro ambiente.' }),
+      el('label', { text: 'API_BASE_URL', children: [apiInput] }),
+      el('button', { class: 'btn primary', text: 'Salvar API', attrs: { type: 'button' } }),
+    ],
+  });
+
+  const logoutButton = el('button', { class: 'btn danger', text: 'Sair da conta', attrs: { type: 'button' } });
+
+  const actionsSection = el('section', {
+    class: 'panel',
+    children: [el('h2', { text: 'Sessão' }), logoutButton],
+  });
+
+  main.append(el('header', { class: 'view-header', children: [el('h1', { text: 'Configurações' }), el('p', { class: 'muted', text: 'Preferências pessoais e do app.' })] }), profileSection, themeSection, apiSection, actionsSection);
+
+  themeSelect.addEventListener('change', () => {
+    const value = themeSelect.value;
+    localStorage.setItem('fp:theme', value);
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const resolved = value === 'system' ? (prefersDark ? 'dark' : 'light') : value;
+    document.documentElement.setAttribute('data-theme', resolved);
+    store.set('ui:theme', resolved);
+    Toast.show({ message: 'Tema atualizado.', type: 'success' });
+  });
+
+  apiSection.querySelector('button').addEventListener('click', () => {
+    const value = apiInput.value.trim();
+    if (!value) {
+      Toast.show({ message: 'Informe uma URL válida.', type: 'danger' });
+      return;
+    }
+    localStorage.setItem('fp:api_url', value);
+    Toast.show({ message: 'URL da API salva! O app será recarregado.', type: 'success' });
+    setTimeout(() => window.location.reload(), 800);
+  });
+
+  logoutButton.addEventListener('click', () => {
+    auth.logout();
+    Toast.show({ message: 'Até breve!', type: 'info' });
+    router.go('#/login');
+  });
+
+  return {
+    render: async () => layout,
+  };
+};
+
+export default SettingsView;

--- a/financas-pessoais-pro-web/src/views/SignupView.js
+++ b/financas-pessoais-pro-web/src/views/SignupView.js
@@ -1,0 +1,82 @@
+import { el } from '../utils/dom.js';
+import { isEmail, minLength, match, validateForm } from '../utils/validate.js';
+import { signup } from '../api/endpoints.js';
+import router from '../router.js';
+import Toast from '../components/Toast.js';
+import Loader from '../components/Loader.js';
+import confetti from '../effects/confetti.js';
+
+const SignupView = () => {
+  const container = el('div', { class: 'auth-view' });
+
+  const nameInput = el('input', {
+    type: 'text',
+    id: 'signup-name',
+    attrs: { placeholder: ' ', autocomplete: 'name' },
+  });
+  const emailInput = el('input', {
+    type: 'email',
+    id: 'signup-email',
+    attrs: { placeholder: ' ', autocomplete: 'email' },
+  });
+  const passwordInput = el('input', {
+    type: 'password',
+    id: 'signup-password',
+    attrs: { placeholder: ' ', autocomplete: 'new-password' },
+  });
+  const confirmInput = el('input', {
+    type: 'password',
+    id: 'signup-confirm',
+    attrs: { placeholder: ' ', autocomplete: 'new-password' },
+  });
+
+  const form = el('form', {
+    class: 'auth-card glass',
+    attrs: { novalidate: 'true' },
+    children: [
+      el('h1', { text: 'Crie sua conta' }),
+      el('p', { class: 'muted', text: 'Organize suas finanças com estilo.' }),
+      el('label', { class: 'floating', attrs: { for: 'signup-name' }, children: [nameInput, el('span', { text: 'Nome completo' })] }),
+      el('label', { class: 'floating', attrs: { for: 'signup-email' }, children: [emailInput, el('span', { text: 'E-mail' })] }),
+      el('label', { class: 'floating', attrs: { for: 'signup-password' }, children: [passwordInput, el('span', { text: 'Senha' })] }),
+      el('label', { class: 'floating', attrs: { for: 'signup-confirm' }, children: [confirmInput, el('span', { text: 'Confirmar senha' })] }),
+      el('button', { class: 'btn primary', text: 'Cadastrar', attrs: { type: 'submit' } }),
+      el('p', { class: 'muted', html: 'Já possui login? <a href="#/login">Entrar</a>' }),
+    ],
+  });
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const { valid, errors } = validateForm({
+      name: [{ rule: () => minLength(nameInput.value, 3), message: 'Informe seu nome completo.' }],
+      email: [{ rule: () => isEmail(emailInput.value), message: 'E-mail inválido.' }],
+      password: [{ rule: () => minLength(passwordInput.value, 8), message: 'Senha deve ter ao menos 8 caracteres.' }],
+      confirm: [{ rule: () => match(confirmInput.value, passwordInput.value), message: 'As senhas não coincidem.' }],
+    });
+    if (!valid) {
+      Toast.show({ message: Object.values(errors)[0], type: 'danger' });
+      form.classList.add('shake');
+      setTimeout(() => form.classList.remove('shake'), 400);
+      return;
+    }
+    try {
+      Loader.show();
+      await signup({ name: nameInput.value, email: emailInput.value, password: passwordInput.value });
+      confetti();
+      Toast.show({ message: 'Conta criada com sucesso!', type: 'success' });
+      router.go('#/dashboard');
+    } catch (error) {
+      Toast.show({ message: error.message || 'Erro ao criar conta.', type: 'danger' });
+    } finally {
+      Loader.hide();
+    }
+  });
+
+  container.appendChild(form);
+
+  return {
+    render: async () => container,
+  };
+};
+
+export default SignupView;

--- a/financas-pessoais-pro-web/src/views/TransactionsView.js
+++ b/financas-pessoais-pro-web/src/views/TransactionsView.js
@@ -1,0 +1,268 @@
+import { el } from '../utils/dom.js';
+import Navbar from '../components/Navbar.js';
+import Sidebar from '../components/Sidebar.js';
+import Table from '../components/Table.js';
+import Modal from '../components/Modal.js';
+import Toast from '../components/Toast.js';
+import Loader from '../components/Loader.js';
+import { formatCurrency, formatDateTime } from '../utils/format.js';
+import { accountsApi, categoriesApi, transactionsApi } from '../api/endpoints.js';
+import store from '../state/store.js';
+
+const TransactionsView = () => {
+  const sidebar = Sidebar();
+  const navbar = Navbar();
+  const main = el('main', { class: 'app-main', attrs: { tabindex: '-1' } });
+  const layout = el('div', { class: 'app-layout', children: [sidebar, el('div', { class: 'app-content', children: [navbar, main] })] });
+
+  const header = el('header', {
+    class: 'view-header',
+    children: [
+      el('div', {
+        children: [el('h1', { text: 'Transações' }), el('p', { class: 'muted', text: 'Controle completo de lançamentos.' })],
+      }),
+      el('button', { class: 'btn primary', text: 'Nova transação', attrs: { type: 'button' } }),
+    ],
+  });
+
+  const filters = el('form', {
+    class: 'filters',
+    children: [
+      el('label', { text: 'Período', children: [el('input', { type: 'date', id: 'filter-from' }), el('input', { type: 'date', id: 'filter-to' })] }),
+      el('label', { text: 'Conta', children: [el('select', { id: 'filter-account', children: [el('option', { value: '', text: 'Todas' })] })] }),
+      el('label', { text: 'Categoria', children: [el('select', { id: 'filter-category', children: [el('option', { value: '', text: 'Todas' })] })] }),
+      el('label', { text: 'Tipo', children: [el('select', { id: 'filter-type', children: [el('option', { value: '', text: 'Ambos' }), el('option', { value: 'IN', text: 'Entrada' }), el('option', { value: 'OUT', text: 'Saída' })] })] }),
+      el('label', { text: 'Buscar', children: [el('input', { type: 'search', id: 'filter-search', attrs: { placeholder: 'Descrição' } })] }),
+      el('button', { class: 'btn ghost', text: 'Aplicar', attrs: { type: 'submit' } }),
+    ],
+  });
+
+  const table = Table({
+    columns: [
+      { key: 'occurredAt', label: 'Data', sortable: true, render: (value) => formatDateTime(value) },
+      { key: 'description', label: 'Descrição', sortable: true },
+      { key: 'accountName', label: 'Conta', sortable: true },
+      { key: 'categoryName', label: 'Categoria', sortable: true },
+      { key: 'type', label: 'Tipo', sortable: true, render: (value) => (value === 'IN' ? '<span class="tag positive">Entrada</span>' : '<span class="tag negative">Saída</span>') },
+      { key: 'amount', label: 'Valor', sortable: true, render: (value) => formatCurrency(value) },
+      {
+        key: 'actions',
+        label: 'Ações',
+        render: (_, item) => {
+          const wrapper = el('div', { class: 'table-actions' });
+          const edit = el('button', { class: 'btn ghost', text: 'Editar', attrs: { type: 'button' } });
+          const remove = el('button', { class: 'btn ghost danger', text: 'Excluir', attrs: { type: 'button' } });
+          edit.addEventListener('click', (event) => {
+            event.stopPropagation();
+            openForm(item);
+          });
+          remove.addEventListener('click', (event) => {
+            event.stopPropagation();
+            confirmDelete(item);
+          });
+          wrapper.append(edit, remove);
+          return wrapper;
+        },
+      },
+    ],
+    perPage: 15,
+  });
+
+  main.append(header, filters, table.element);
+
+  const fromInput = filters.querySelector('#filter-from');
+  const toInput = filters.querySelector('#filter-to');
+  const now = new Date();
+  fromInput.value = new Date(now.getFullYear(), now.getMonth(), 1).toISOString().slice(0, 10);
+  toInput.value = now.toISOString().slice(0, 10);
+
+  let accounts = [];
+  let categories = [];
+
+  const loadFilters = async () => {
+    const [accountsList, categoriesList] = await Promise.all([accountsApi.list(), categoriesApi.list()]);
+    accounts = accountsList;
+    categories = categoriesList;
+    const accountSelect = filters.querySelector('#filter-account');
+    const categorySelect = filters.querySelector('#filter-category');
+    accountSelect.innerHTML = '<option value="">Todas</option>' + accounts.map((account) => `<option value="${account.id}">${account.name}</option>`).join('');
+    categorySelect.innerHTML = '<option value="">Todas</option>' + categories.map((category) => `<option value="${category.id}">${category.name}</option>`).join('');
+  };
+
+  const getFilterValues = () => ({
+    from: filters.querySelector('#filter-from').value,
+    to: filters.querySelector('#filter-to').value,
+    accountId: filters.querySelector('#filter-account').value,
+    categoryId: filters.querySelector('#filter-category').value,
+    type: filters.querySelector('#filter-type').value,
+    search: filters.querySelector('#filter-search').value,
+  });
+
+  const loadTransactions = async () => {
+    try {
+      Loader.show();
+      const params = getFilterValues();
+      const transactions = await transactionsApi.list(params);
+      const formatted = transactions.map((transaction) => ({
+        ...transaction,
+        accountName: transaction.account?.name ?? '-',
+        categoryName: transaction.category?.name ?? '-',
+      }));
+      table.update(formatted);
+    } catch (error) {
+      Toast.show({ message: error.message || 'Erro ao carregar transações.', type: 'danger' });
+    } finally {
+      Loader.hide();
+    }
+  };
+
+  const openForm = (transaction = null) => {
+    const form = el('form', {
+      class: 'form-grid',
+      children: [
+        el('label', {
+          text: 'Conta',
+          children: [
+            el('select', {
+              id: 'transaction-account',
+              children: accounts.map((account) => el('option', { value: account.id, text: account.name })),
+            }),
+          ],
+        }),
+        el('label', {
+          text: 'Categoria',
+          children: [
+            el('select', {
+              id: 'transaction-category',
+              children: categories.map((category) => el('option', { value: category.id, text: category.name })),
+            }),
+          ],
+        }),
+        el('label', {
+          text: 'Tipo',
+          children: [
+            el('select', {
+              id: 'transaction-type',
+              children: [
+                el('option', { value: 'IN', text: 'Entrada' }),
+                el('option', { value: 'OUT', text: 'Saída' }),
+              ],
+            }),
+          ],
+        }),
+        el('label', {
+          text: 'Valor',
+          children: [el('input', { type: 'number', step: '0.01', id: 'transaction-amount', value: transaction?.amount ?? 0 })],
+        }),
+        el('label', {
+          text: 'Descrição',
+          children: [el('input', { type: 'text', id: 'transaction-description', value: transaction?.description ?? '' })],
+        }),
+        el('label', {
+          text: 'Data/Hora',
+          children: [el('input', { type: 'datetime-local', id: 'transaction-date', value: transaction ? transaction.occurredAt.slice(0, 16) : new Date().toISOString().slice(0, 16) })],
+        }),
+      ],
+    });
+
+    const accountSelect = form.querySelector('#transaction-account');
+    const categorySelect = form.querySelector('#transaction-category');
+    const typeSelect = form.querySelector('#transaction-type');
+
+    if (transaction) {
+      accountSelect.value = transaction.account?.id;
+      categorySelect.value = transaction.category?.id;
+      typeSelect.value = transaction.type;
+    }
+
+    const modal = Modal({
+      title: transaction ? 'Editar transação' : 'Nova transação',
+      content: form,
+      actions: [
+        { label: 'Cancelar', class: 'ghost', onClick: ({ close }) => close() },
+        {
+          label: transaction ? 'Atualizar' : 'Criar',
+          class: 'primary',
+          onClick: async ({ close }) => {
+            const payload = {
+              accountId: accountSelect.value,
+              categoryId: categorySelect.value,
+              type: typeSelect.value,
+              amount: Number(form.querySelector('#transaction-amount').value),
+              description: form.querySelector('#transaction-description').value,
+              occurredAt: (() => {
+                const value = form.querySelector('#transaction-date').value;
+                return value ? new Date(value).toISOString() : new Date().toISOString();
+              })(),
+            };
+            try {
+              Loader.show();
+              if (transaction) {
+                await transactionsApi.update(transaction.id, payload);
+                Toast.show({ message: 'Transação atualizada.', type: 'success' });
+              } else {
+                await transactionsApi.create(payload);
+                Toast.show({ message: 'Transação registrada!', type: 'success' });
+                store.set('dashboard:refresh', Date.now());
+              }
+              close();
+              loadTransactions();
+            } catch (error) {
+              Toast.show({ message: error.message || 'Erro ao salvar transação.', type: 'danger' });
+            } finally {
+              Loader.hide();
+            }
+          },
+        },
+      ],
+    });
+    document.getElementById('modal-root').appendChild(modal.element);
+  };
+
+  const confirmDelete = (transaction) => {
+    const modal = Modal({
+      title: 'Excluir transação',
+      content: el('p', { text: `Excluir "${transaction.description}"?` }),
+      actions: [
+        { label: 'Cancelar', class: 'ghost', onClick: ({ close }) => close() },
+        {
+          label: 'Excluir',
+          class: 'danger',
+          onClick: async ({ close }) => {
+            try {
+              Loader.show();
+              await transactionsApi.remove(transaction.id);
+              Toast.show({ message: 'Transação removida.', type: 'success' });
+              close();
+              loadTransactions();
+            } catch (error) {
+              Toast.show({ message: error.message || 'Erro ao remover transação.', type: 'danger' });
+            } finally {
+              Loader.hide();
+            }
+          },
+        },
+      ],
+    });
+    document.getElementById('modal-root').appendChild(modal.element);
+  };
+
+  filters.addEventListener('submit', (event) => {
+    event.preventDefault();
+    loadTransactions();
+  });
+
+  header.querySelector('button').addEventListener('click', () => openForm());
+
+  store.subscribe('ui:search', (term) => table.filter(term));
+
+  return {
+    render: async () => {
+      await loadFilters();
+      await loadTransactions();
+      return layout;
+    },
+  };
+};
+
+export default TransactionsView;

--- a/financas-pessoais-pro-web/src/views/TransfersView.js
+++ b/financas-pessoais-pro-web/src/views/TransfersView.js
@@ -1,0 +1,119 @@
+import { el } from '../utils/dom.js';
+import Navbar from '../components/Navbar.js';
+import Sidebar from '../components/Sidebar.js';
+import Table from '../components/Table.js';
+import Toast from '../components/Toast.js';
+import Loader from '../components/Loader.js';
+import confetti from '../effects/confetti.js';
+import { formatCurrency, formatDateTime } from '../utils/format.js';
+import { accountsApi, transfersApi } from '../api/endpoints.js';
+import store from '../state/store.js';
+
+const TransfersView = () => {
+  const sidebar = Sidebar();
+  const navbar = Navbar();
+  const main = el('main', { class: 'app-main', attrs: { tabindex: '-1' } });
+  const layout = el('div', { class: 'app-layout', children: [sidebar, el('div', { class: 'app-content', children: [navbar, main] })] });
+
+  const header = el('header', {
+    class: 'view-header',
+    children: [
+      el('div', { children: [el('h1', { text: 'Transferências' }), el('p', { class: 'muted', text: 'Transfira entre contas e acompanhe o histórico.' })] }),
+    ],
+  });
+
+  const form = el('form', {
+    class: 'panel form-grid',
+    children: [
+      el('label', { text: 'Conta origem', children: [el('select', { id: 'transfer-from' })] }),
+      el('label', { text: 'Conta destino', children: [el('select', { id: 'transfer-to' })] }),
+      el('label', { text: 'Valor', children: [el('input', { type: 'number', step: '0.01', id: 'transfer-amount' })] }),
+      el('label', { text: 'Descrição', children: [el('input', { type: 'text', id: 'transfer-description' })] }),
+      el('label', { text: 'Data/Hora', children: [el('input', { type: 'datetime-local', id: 'transfer-date', value: new Date().toISOString().slice(0, 16) })] }),
+      el('button', { class: 'btn primary', text: 'Transferir', attrs: { type: 'submit' } }),
+    ],
+  });
+
+  const table = Table({
+    columns: [
+      { key: 'occurredAt', label: 'Data', render: (value) => formatDateTime(value), sortable: true },
+      { key: 'fromAccount', label: 'Origem', sortable: true },
+      { key: 'toAccount', label: 'Destino', sortable: true },
+      { key: 'amount', label: 'Valor', sortable: true, render: (value) => formatCurrency(value) },
+      { key: 'description', label: 'Descrição', sortable: true },
+    ],
+    perPage: 10,
+  });
+
+  main.append(header, form, table.element);
+
+  const loadAccounts = async () => {
+    const accounts = await accountsApi.list();
+    const options = accounts.map((account) => `<option value="${account.id}">${account.name}</option>`).join('');
+    form.querySelector('#transfer-from').innerHTML = options;
+    form.querySelector('#transfer-to').innerHTML = options;
+  };
+
+  const loadTransfers = async () => {
+    try {
+      Loader.show();
+      const transfers = await transfersApi.list();
+      const formatted = transfers.map((transfer) => ({
+        ...transfer,
+        fromAccount: transfer.fromAccount?.name,
+        toAccount: transfer.toAccount?.name,
+      }));
+      table.update(formatted);
+    } catch (error) {
+      Toast.show({ message: error.message || 'Erro ao carregar transferências.', type: 'danger' });
+    } finally {
+      Loader.hide();
+    }
+  };
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const payload = {
+      fromAccountId: form.querySelector('#transfer-from').value,
+      toAccountId: form.querySelector('#transfer-to').value,
+      amount: Number(form.querySelector('#transfer-amount').value),
+      description: form.querySelector('#transfer-description').value,
+      occurredAt: (() => {
+        const value = form.querySelector('#transfer-date').value;
+        return value ? new Date(value).toISOString() : new Date().toISOString();
+      })(),
+    };
+
+    if (payload.fromAccountId === payload.toAccountId) {
+      Toast.show({ message: 'Escolha contas diferentes para transferir.', type: 'danger' });
+      return;
+    }
+
+    try {
+      Loader.show();
+      await transfersApi.create(payload);
+      Toast.show({ message: 'Transferência realizada!', type: 'success' });
+      confetti();
+      form.reset();
+      form.querySelector('#transfer-date').value = new Date().toISOString().slice(0, 16);
+      loadTransfers();
+      store.set('dashboard:refresh', Date.now());
+    } catch (error) {
+      Toast.show({ message: error.message || 'Erro ao realizar transferência.', type: 'danger' });
+    } finally {
+      Loader.hide();
+    }
+  });
+
+  store.subscribe('ui:search', (term) => table.filter(term));
+
+  return {
+    render: async () => {
+      await loadAccounts();
+      await loadTransfers();
+      return layout;
+    },
+  };
+};
+
+export default TransfersView;


### PR DESCRIPTION
## Summary
- implement hash-based SPA with authentication guards, layout shell, and service worker for the Finanças Pessoais PRO frontend
- add reusable UI components (navbar, sidebar, tables, charts, modals, toasts) and visual effects (tilt, parallax, confetti) with themed glassmorphism styling
- integrate all API endpoints for accounts, categories, transactions, transfers, recurrings, budgets, and reports, including dashboards, CRUD views, and settings management

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e1c0ad052c8332b0aad7ccba79793c